### PR TITLE
Fix for animations not playing more than 2 frames

### DIFF
--- a/src/kaboom.js
+++ b/src/kaboom.js
@@ -2907,7 +2907,7 @@ function sprite(id, conf = {}) {
 			if (this._animTimer >= this.animSpeed) {
 				// TODO: anim dir
 				this.frame++;
-				if (this.frame > anim[1]) {
+				if (this.frame > anim[anim.length - 1]) {
 					if (this._animLooping) {
 						this.frame = anim[0];
 					} else {


### PR DESCRIPTION
Fixed issue where animations with more than 2 frames wouldn't play beyond 2 frames. Only had to swap one line to allow for a variable length on the anim array.