### PR TITLE
Removed extra argument for `rgb` in documentation

### DIFF
--- a/site/api.js
+++ b/site/api.js
@@ -823,7 +823,6 @@ c.clone(); // => rgba(0, 0, 1, 1)
 				a("r", "red"),
 				a("g", "green"),
 				a("b", "blue"),
-				a("a", "alpha"),
 			], null, "shorthand for rgba() with a = 1", ``),
 			f("rand", [
 				a("a", "a"),


### PR DESCRIPTION
Just noticed that `rgb` had the `a` argument in the docs.