### PR TITLE
Add kaboom global to site guide

### DIFF
--- a/site/pub/guide/10.js
+++ b/site/pub/guide/10.js
@@ -1,5 +1,7 @@
 // TALK: let's add a background image
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 

--- a/site/pub/guide/11.js
+++ b/site/pub/guide/11.js
@@ -2,6 +2,8 @@
 // TALK: and make the image origin point top left (it defaults to center, so you only see 1/4 of it before)
 // TALK: then let's make the pipes!
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 

--- a/site/pub/guide/12.js
+++ b/site/pub/guide/12.js
@@ -3,6 +3,8 @@
 // TALK: we use a const PIPE_OPEN to define the distance between 2 pipes, we give it a generous 120 for now
 // TALK: next step we'll make the core mechanism of the game: make the pipe move towards the player (yes in flappy birds it's the pipes moving not the bird!)
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/13.js
+++ b/site/pub/guide/13.js
@@ -4,6 +4,8 @@
 // TALK: in this case we make them move left every frame by PIPE_SPEED
 // TALK: now we have moving pipes, let's complete this mechanism by making the bird actually have to jump over it!
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/14.js
+++ b/site/pub/guide/14.js
@@ -1,6 +1,8 @@
 // TALK: first let's remove the baby platform, and make the game restart when player falls
 // TALK: we do this by giving birdy an action to run every frame, to check if it's position is out of screen
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/15.js
+++ b/site/pub/guide/15.js
@@ -2,6 +2,8 @@
 // TALK: we do this by calling birdy.collides() which checks for collision between birdy and all objects with a certain tag
 // TALK: then we have our basic mechanics!
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/16.js
+++ b/site/pub/guide/16.js
@@ -5,6 +5,8 @@
 // TALK: there's only 1 set of pipes! that's not really that fun
 // TALK: we gotta make some pipe generation mechanism
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/17.js
+++ b/site/pub/guide/17.js
@@ -3,6 +3,8 @@
 // TALK: but you may have noticed all pipes have the same position which is no fun
 // TALK: gotta make those random man
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/18.js
+++ b/site/pub/guide/18.js
@@ -3,6 +3,8 @@
 // TALK: kaboom! the game instantly becomes fun!
 // TALK: next let's add a score counter
 
+kaboom.global();
+
 loadSprite("bg", "/pub/img/bg.png");
 loadSprite("birdy", "/pub/img/birdy.png");
 loadSprite("pipe", "/pub/img/pipe.png");

--- a/site/pub/guide/3.js
+++ b/site/pub/guide/3.js
@@ -1,5 +1,7 @@
 // TALK: first let's load a sprite by loadSprite(), passing in the sprite name, and the sprite url
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init();

--- a/site/pub/guide/4.js
+++ b/site/pub/guide/4.js
@@ -2,6 +2,8 @@
 // TALK: a game object in kaboom consists of a list of components, describing its behaviors
 // TALK: to make a birdy, we first give it a sprite("birdy") component so it knows what to draw
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init();

--- a/site/pub/guide/5.js
+++ b/site/pub/guide/5.js
@@ -1,6 +1,8 @@
 // TALK: then we give it a pos(100, 100) component to tell what position to draw on screen
 // TALK: oops it looks like our birdy is too small
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init();

--- a/site/pub/guide/6.js
+++ b/site/pub/guide/6.js
@@ -2,6 +2,8 @@
 // TALK: but the birdy still looks weird...
 // TALK: it's floating in the air! that's not right!
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init({

--- a/site/pub/guide/7.js
+++ b/site/pub/guide/7.js
@@ -3,6 +3,8 @@
 // TALK: but we don't want the birdy to keep falling
 // TALK: let's make a temporary platform for the bird to stay on
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init({

--- a/site/pub/guide/8.js
+++ b/site/pub/guide/8.js
@@ -2,6 +2,8 @@
 // TALK: and by giving it a solid() component, kaboom knows it's a solid physics object and things can't move through it!
 // TALK: now it's finally time to make it jump!
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init({

--- a/site/pub/guide/9.js
+++ b/site/pub/guide/9.js
@@ -2,6 +2,8 @@
 // TALK: we register a keyPress event that get's called everytime player presses the "space" key
 // TALK: then we call method jump() provided by body() component to make it jump
 
+kaboom.global();
+
 loadSprite("birdy", "/pub/img/birdy.png");
 
 init({


### PR DESCRIPTION
Due to `kaboom.global()` being removed from the `genGame.js` script in this commit:

https://github.com/replit/kaboom/commit/e480fb5bf5c252b36e7325e79f83dc9c2f8d8c38#diff-0ddd15db301bfe15cb6bda312966ae5695dae3bd45a7fdddef4d50246e230837L63

The site guide doesn't load the sprites etc.

I've replicated what you have done in another commit for the examples, but it needs to be done for the interactive guide too.

Let me know if you need any other changes.

Many thanks!