### PR TITLE
Include key when calling keypress callback functions.

### DIFF
--- a/src/kaboom.js
+++ b/src/kaboom.js
@@ -2545,25 +2545,25 @@ function start(name, ...args) {
 			// run input checks & callbacks
 			for (const e of scene.events.keyDown) {
 				if (keyIsDown(e.key)) {
-					e.cb();
+					e.cb(e.key);
 				}
 			}
 
 			for (const e of scene.events.keyPress) {
 				if (keyIsPressed(e.key)) {
-					e.cb();
+					e.cb(e.key);
 				}
 			}
 
 			for (const e of scene.events.keyPressRep) {
 				if (keyIsPressedRep(e.key)) {
-					e.cb();
+					e.cb(e.key);
 				}
 			}
 
 			for (const e of scene.events.keyRelease) {
 				if (keyIsReleased(e.key)) {
-					e.cb();
+					e.cb(e.key);
 				}
 			}
 


### PR DESCRIPTION
Hi! Brilliant library, it's lots of fun to make stuff with!

I noticed if you add the pressed key as an argument to the callback functions it allows for some powerful functionality like the ability to make quick input/dialog prompts to the user such as "Enter your name...".

Example code:
```
keyPress([ASCII_CHARS], (key) => {
    if (gameState.promptOpen) {
      promptInput(key);
    }
  });
```

Perhaps there is already an easy way to do this though that I just missed!

Many Thanks!