### PR TITLE
Fix drive example car animation reference

### DIFF
--- a/site/api.js
+++ b/site/api.js
@@ -187,11 +187,14 @@ loadSprite("froggy", "froggy.png", {
 		jump: [3],
 	},
 });
-
-// load with aseprite sprite sheet
-loadSprite("froggy", "froggy.png", {
-	aseSpriteSheet: "froggy.json", // use spritesheet exported from aseprite
-});
+			`),
+			f("loadAseprite", [
+				a("name", "name of sprite"),
+				a("imgSrc", "image source"),
+				a("jsonSrc", "use spritesheet exported from aseprite"),
+			], null, "load an Aseprite sprite sheet", `
+// use spritesheet json exported from aseprite
+loadAseprite("froggy", "froggy.png", "froggy.json")
 			`),
 			f("loadSound", [
 				a("name", "name of sound"),

--- a/site/pub/examples/drive.js
+++ b/site/pub/examples/drive.js
@@ -3,9 +3,7 @@ kaboom.global();
 loadRoot("/pub/img/");
 loadSprite("sky", "sky.png");
 loadSprite("road", "road.png");
-loadSprite("car", "car.png", {
-	aseSpriteSheet: "car.json",
-});
+loadAseprite("car", "car.png", "car.json");
 loadSprite("apple", "apple.png");
 loadSprite("pineapple", "pineapple.png");
 


### PR DESCRIPTION
The car animation is broken on the example due Aseprite support being ported over to `loadAseprite()` in kaboom version `0.2.0` instead of using it inside of a parameter inside of `loadSprite()`.

Animation now runs succesfully.

Also updated the documentation for `loadAseprite()`as well.

