### PR TITLE
Added a ceiling for flappy bird so that you can't fly above everything

### DIFF
--- a/examples/flappy.js
+++ b/examples/flappy.js
@@ -38,6 +38,14 @@ scene("main", () => {
 		layer("bg"),
 	]);
 
+	// ceiling
+	add([
+		rect(640, .001),
+		pos(0, 0),
+		color(0, 0, 1, 0),
+		solid()
+	]);
+
 	// a game object consists of a list of components and tags
 	const birdy = add([
 		// sprite() means it's drawn with a sprite of name "birdy" (defined above in 'loadSprite')


### PR DESCRIPTION
Well, I added a thin rectangle that is solid so that flappy bird wouldn't go above it. Was this in the original game? idk, but it seems odd to just fly over everything and get points for it.