### PR TITLE
FIX typeError cannot redefine property width

### DIFF
--- a/examples/button.js
+++ b/examples/button.js
@@ -1,5 +1,3 @@
-// TODO: fix
-
 kaboom({
 	global: true,
 	fullscreen: true,
@@ -17,11 +15,9 @@ scene("main", () => {
 			color(1, 1, 1),
 		]);
 
-		// TODO: text() and rect() both have 'width'
 		add([
 			text(txt),
 			pos(p),
-			rect(100, 100),
 			origin("center"),
 			color(0, 0, 0),
 		]);


### PR DESCRIPTION
There was an error in the Button example:

![kaboom-button-example-typeerror-width](https://user-images.githubusercontent.com/13135150/124384380-34f9e500-dcd1-11eb-8026-5168e0b3968d.png)

So I fixed it, and it now works as intended:

![kaboom-button-example-typeerror-width-fixed](https://user-images.githubusercontent.com/13135150/124384410-55c23a80-dcd1-11eb-9587-6044cba2eff7.gif)
