### PR TITLE
examples/rpg: fix error resolve is not a function

### DIFF
--- a/examples/rpg.js
+++ b/examples/rpg.js
@@ -144,7 +144,7 @@ scene("main", (levelIdx) => {
 	}
 
 	player.action(() => {
-		player.resolve();
+		player.pushOutAll();
 	});
 
 });


### PR DESCRIPTION
Fix error player.resolve() is not a function:

![kaboom-player-example-resolve-is-not-a-function](https://user-images.githubusercontent.com/13135150/124385037-54ded800-dcd4-11eb-9783-c5acf388003b.png)

After the fix, the example works as intended:

![kaboom-rpg-example-fix-bug-resolve-not-a-function](https://user-images.githubusercontent.com/13135150/124385047-63c58a80-dcd4-11eb-8f11-38ce6a2d5243.gif)
