### PR TITLE
api.js: replace resolve with pushOutAll

### DIFF
--- a/site/api.js
+++ b/site/api.js
@@ -489,7 +489,7 @@ if (obj.isHovered()) {
 // check if a point is inside the obj area
 obj.hasPt();
 
-// pushOutAll all collisions with objects with 'solid'
+// pushOutAll resolves all collisions with objects with 'solid'
 // for now this checks against all solid objs in the scene (this is costly now)
 obj.pushOutAll();
 			`),

--- a/site/api.js
+++ b/site/api.js
@@ -489,9 +489,9 @@ if (obj.isHovered()) {
 // check if a point is inside the obj area
 obj.hasPt();
 
-// resolve all collisions with objects with 'solid'
+// pushOutAll all collisions with objects with 'solid'
 // for now this checks against all solid objs in the scene (this is costly now)
-obj.resolve();
+obj.pushOutAll();
 			`),
 			f("body", "component for falling / jumping", `
 const player = add([
@@ -522,15 +522,15 @@ player.on("grounded", () => {
 	console.log("horray!");
 });
 			`),
-			f("solid", "mark the obj so other objects can't move past it if they have an area and resolve()", `
+			f("solid", "mark the obj so other objects can't move past it if they have an area and pushOutAll()", `
 const obj = add([
 	sprite("wall"),
 	solid(),
 ]);
 
-// need to call resolve() (provided by 'area') to make sure they cannot move past solid objs
+// need to call pushOutAll() (provided by 'area') to make sure they cannot move past solid objs
 player.action(() => {
-	player.resolve();
+	player.pushOutAll();
 });
 			`),
 			f("origin", "the origin to draw the object (default topleft)", `


### PR DESCRIPTION
As stated in this comment https://github.com/replit/kaboom/pull/91#issuecomment-874288963 the `resolve` method is now called `pushOutAll`.

I updated the API documentation to reflect this change.