### PR TITLE
Make component functions accept parent  component as first argument

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -470,7 +470,7 @@ function add(comps: Comp[]): GameObj {
 
 				// event / custom method
 				if (typeof comp[k] === "function") {
-					const func = comp[k].bind(this);
+					const func = comp[k].bind(this, obj);
 					if (COMP_EVENTS.has(k)) {
 						this.on(k, func);
 						continue;


### PR DESCRIPTION
Motivation: Currently when making custom components, we rely on "this" to access the properties of parent component. 

Since "this" can be confusing to beginners (including myself), having component as a first argument will always will make things clearer, it will also make the functions easier to test.

Here is a sample example

Before=
```
function big() {
	let timer = 0;
	let isBig = false;
	return {
		isBig() {
			return isBig;
		},
		smallify() {
			this.scale = vec2(1);
			timer = 0;
			isBig = false;
		},
		biggify(time) {
			this.scale = vec2(2);
			timer = time;
			isBig = true;
		},
	};
}

```

Proposed change
```
function big() {
	let timer = 0;
	let isBig = false;
	return {
		isBig() {
			return isBig;
		},
		smallify(comp) {
			comp.scale = vec2(1);
			timer = 0;
			isBig = false;
		},
		biggify(comp, time) {
			comp.scale = vec2(2);
			timer = time;
			isBig = true;
		},
	};
}

```