### PR TITLE
Add complex type for add method

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -422,15 +422,22 @@ const COMP_EVENTS = new Set([
 	"inspect",
 ]);
 
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+type Defined<T> = T extends any ? Pick<T, { [K in keyof T]-?: T[K] extends undefined ? never : K }[keyof T]> : never;
+type Expand<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+
+type AddParameters = (PosComp | ScaleComp | RotateComp | ColorComp | OriginComp | LayerComp | AreaComp | SpriteComp | BodyComp | TextComp);
+
 // TODO: make tags also comp?
-function add(comps: Comp[]): GameObj {
+function add<T extends AddParameters>(comps: ReadonlyArray<T>): Expand<UnionToIntersection<Defined<T>>> & GameObj {
 
 	const compStates = {};
 	const customState = {};
 	const events = {};
 	const tags = [];
 
-	const obj: GameObj = {
+	const obj = {
 
 		_id: null,
 		hidden: false,
@@ -609,7 +616,7 @@ function add(comps: Comp[]): GameObj {
 		}
 	}
 
-	return obj;
+	return obj as unknown as Expand<UnionToIntersection<Defined<T>>> & GameObj;
 
 }
 


### PR DESCRIPTION
Creates a dynamic type based on what's passed into the kaboom.add method.

This will merge the type of each object in an array and return that combined object.

It's often difficult to prove TypeScript changes, but here's an example in screenshots:

Before:
![image](https://user-images.githubusercontent.com/9075434/127766234-dae07e20-3995-4edb-9ed5-67198bdc6fba.png)
Limited list of suggestions - Only GameObj properties are suggested.

![image](https://user-images.githubusercontent.com/9075434/127766259-5557a4e1-7676-4687-a974-f17edbf71528.png)
No valid IntelliSense for functions on any of the Comp's passed into the add method.


After: 
![image](https://user-images.githubusercontent.com/9075434/127766180-edcc0e36-d4f1-4840-afb1-fa94530cdede.png)
Full list of IntelliSense suggestions

![image](https://user-images.githubusercontent.com/9075434/127766197-90a0a3db-f0ba-4032-bb92-db63b682a994.png)
Correct IntelliSense for available methods.

This is my first time using kaboom, so bear with me. Open to feedback :)