### PR TITLE
[RFC] Allow passing components directly as arguments, and support composition

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -334,7 +334,7 @@ const COMP_EVENTS = new Set([
 	"inspect",
 ]);
 
-function make<T>(comps: CompList<T>): Character<T> {
+function make<T>(comps: FlatCompList<T>): Character<T> {
 
 	const compStates = new Map();
 	const customState = {};

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -527,11 +527,13 @@ function make<T>(comps: CompList<T>): Character<T> {
 
 }
 
-function add<T>(comps: CompList<T>): Character<T> {
-	const obj = make(comps);
+function add<A extends unknown[]>(...comps: [...A]): Character<RecursiveElementType<A>> {
+	const flatComps = comps.flat(Infinity) as RecursiveElementType<A>[];
+	const obj = make(flatComps);
 	obj._id = game.objs.push(obj);
 	obj.trigger("add");
 	ready(() => obj.trigger("load"));
+
 	return obj;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1423,6 +1423,11 @@ type Expand<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
 type MergeObj<T> = Expand<UnionToIntersection<Defined<T>>>;
 type MergeComps<T> = Omit<MergeObj<T>, keyof Comp>;
 
+// Gets an element type from a recursive array type
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#recursive-conditional-types
+type RecursiveElementType<T> = T extends ReadonlyArray<infer U> ? RecursiveElementType<U> : T;
+
+
 type CompList<T> = Array<T | Tag>;
 type DynCompList<T> = CompList<T> | ((...args: any[]) => CompList<T>);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1428,8 +1428,8 @@ type MergeComps<T> = Omit<MergeObj<T>, keyof Comp>;
 type RecursiveElementType<T> = T extends ReadonlyArray<infer U> ? RecursiveElementType<U> : T;
 
 
-type CompList<T> = Array<T | Tag>;
-type DynCompList<T> = CompList<T> | ((...args: any[]) => CompList<T>);
+type CompList<T> = Array<T | Tag | CompList<T>>;
+type FlatCompList<T> = Array<T | Tag>;
 
 type Key =
 	| "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"


### PR DESCRIPTION
There's two folds for this RFC. Firstly, I think it would be good for beginners to not have to think about passing arrays to `add`. It should accept `add(body(), pos(), area())`. Secondly, as a side-effect of trying to be backwards incompatible, you can now compose components and use them in objects without having to learn array spread syntax. To fully support this form of composition, we can allow infinitely nested arrays.

Before

```ts
const playerComponents = [
       sprite('player'),
       body(),
       area(),
       pos(),
       "player",
];

const evilPlayerComponents = [
  ...playerComponents, // or spreading later when calling add([...playerComponents, ...evilPlayerComponents])
  color(0, 0, 0),
  origin("left"),
];

add(evilPlayerComponents);
```

After


```ts
const playerComponents = [
       sprite('player'),
       body(),
       area(),
       pos(),
       "player",
];

const evilPlayerComponents = [
  playerComponents, // or later when calling add(playerComponents, evilPlayerComponents)
  color(0, 0, 0),
  origin("left"),
];

add(evilPlayerComponents);
```

You can do `add([[[[[body()]]]], pos()])` or any form of nesting, it should still work!

The RFC is fully implemented and typescript supports it.
