### PR TITLE
Added support to x-browser fullscreen

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -361,12 +361,39 @@ function appInit(gconf: AppConf = {}): App {
 	}
 
 	function fullscreen(f?: boolean): boolean {
-		if (document.fullscreenElement) {
-			document.exitFullscreen();
+		const enterFullscreen = (el: any) => {
+			if(el.mozRequestFullScreen) {
+				el.mozRequestFullScreen();
+			} else if (el.webkitRequestFullScreen) {
+				el.webkitRequestFullScreen();
+			} else {
+				el.requestFullscreen();
+			}
+		};
+		
+		const exitFullscreen = (doc: any) => {
+			if(doc.mozExitFullScreen) {
+				doc.mozExitFullScreen();
+			} else if(doc.webkitExitFullScreen) {
+				doc.webkitExitFullScreen();
+			} else {
+				doc.exitFullscreen();
+			}
+		};
+
+		const getFullscreenElement = (doc: any):HTMLElement => {
+			if(doc.mozFullscreenElement !== undefined) return doc.mozFullscreenElement;
+			if(doc.webkitFullscreenElement !== undefined) return doc.webkitFullscreenElement;
+			return doc.fullscreenElement;
+		};
+
+		if (getFullscreenElement(document)) {
+			exitFullscreen(document);
 		} else {
-			app.canvas.requestFullscreen();
+			enterFullscreen(app.canvas);
 		}
-		return document.fullscreenElement != null;
+
+		return !!getFullscreenElement(document);
 	}
 
 	function run(f: () => void) {


### PR DESCRIPTION
Fixes #213

Added the cross browser calls in the fullscreen function defined in app.ts.
Caveats:
- It works on Google Chrome
- It works on Safari Experimental Build for OS X
- Does not work on current Safari stable version
- Does not work on last iOS Safari stable version
- For mobile version, I recommend using Capacitor or Cordova and packing a native app.

Needs help with:
- Testing in Mozilla Firefox
- Testing with MS Edge