### PR TITLE
fix collides() checking for the same obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "kaboom",
 	"description": "kaboom.js is a JavaScript library that helps you make games fast and fun!",
-	"version": "2000.0.0-beta.23",
+	"version": "2000.0.0-beta.24",
 	"license": "MIT",
 	"homepage": "https://kaboomjs.com/",
 	"repository": "github:replit/kaboom",

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -581,7 +581,7 @@ function collides(
 	f: (a: Character, b: Character) => void,
 ): EventCanceller {
 	const e1 = on("collide", t1, (a, b, side) => b.is(t2) && f(a, b));
-	const e2 = on("collide", t1, (a, b, side) => b.is(t1) && f(b, a));
+	const e2 = on("collide", t2, (a, b, side) => b.is(t1) && f(b, a));
 	const e3 = action(t1, (o1: Character) => {
 		o1._checkCollisions(t2, (o2) => {
 			f(o1, o2);


### PR DESCRIPTION
- fixed a typo that's causing objects to check collisions with themselves
- publishes the fix