### PR TITLE
fix doc content overflow

### DIFF
--- a/site/comps/Doc.tsx
+++ b/site/comps/Doc.tsx
@@ -105,7 +105,7 @@ const PropertySignature: React.FC<MemberProps> = ({ data, big }) => (
 );
 
 const FunctionDeclaration: React.FC<EntryProps> = ({ data }) => (
-	<View gap={1}>
+	<View gap={1} stretchX>
 		<Text
 			code
 			color={1}
@@ -119,7 +119,7 @@ const FunctionDeclaration: React.FC<EntryProps> = ({ data }) => (
 );
 
 const TypeAliasDeclaration: React.FC<EntryProps> = ({ data }) => (
-	<View gap={1}>
+	<View gap={1} stretchX>
 		<Text
 			code
 			color={1}


### PR DESCRIPTION
The code block was overflowing on the X axis

before:

<img width="1156" alt="1633625909" src="https://user-images.githubusercontent.com/9929523/136430514-cc5fa039-0da6-487c-babd-34364bb21c4d.png">

after:
<img width="1171" alt="1633625985" src="https://user-images.githubusercontent.com/9929523/136430618-4654aaa8-e754-4eca-accb-cd2d7308575e.png">


