### PR TITLE
add assets listing API

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	reactStrictMode: true,
 	async headers() {
 		return [
-			{ source: "/api/assets/:path*", headers: [
+			{ source: "/api/:path*", headers: [
 				{ key: "Access-Control-Allow-Origin", value: "*" },
 			] },
 		];

--- a/site/pages/api/assets/[kind].ts
+++ b/site/pages/api/assets/[kind].ts
@@ -8,11 +8,8 @@ export default function handler(
 ) {
 
 	const { kind } = req.query;
-
-	const dir = path.resolve(
-		"./public",
-		Array.isArray(kind) ? kind.join("") : kind
-	);
+	// "kind" should always be string here, as URL param won't overwrite
+	const dir = path.resolve("./public", kind as string);
 
 	const [ status, files ] = fs.existsSync(dir)
 		? [ 200, fs


### PR DESCRIPTION
The assets lib in replit workspace is relying on an endpoint to return the list of assets files, which is not present on the new site.

This PR adds the endpoint `/api/assets/[kind]` which returns a list of files of the asset kind (same as the old API)