### PR TITLE
"replace" instead of "push" on play page initial route query setting

### DIFF
--- a/site/pages/play.tsx
+++ b/site/pages/play.tsx
@@ -171,7 +171,7 @@ const Play: React.FC = () => {
 
 	React.useEffect(() => {
 		if (router.isReady && !router.query.demo) {
-			router.push({
+			router.replace({
 				query: {
 					demo: DEF_DEMO,
 				},


### PR DESCRIPTION
"play" page is setting the `demo` query to the default demo name if it's not present in URL, but `router.push` is making the back button useless, changing `push` to `replace` to not mess with browser history stack on this initial setting.