### PR TITLE
improve some number display on inspect

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1821,7 +1821,7 @@ function rect(w: number, h: number): RectComp {
 			});
 		},
 		inspect() {
-			return `${Math.round(this.width)}, ${Math.round(this.height)}`;
+			return `${Math.ceil(this.width)}, ${Math.ceil(this.height)}`;
 		},
 	};
 }


### PR DESCRIPTION
<img width="469" alt="1634149456" src="https://user-images.githubusercontent.com/9929523/137191333-a75219ac-386a-4646-b81d-62df65a32cb6.png">

Rectangle sizes and positions makes sense to round in inspect display, their decimal values are not that informative in inspect mode and they'll clutter the view