### PR TITLE
Don't run loop when document not visible

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -400,6 +400,11 @@ function appInit(gconf: AppConf = {}): App {
 
 		const frame = (t: number) => {
 
+			if (document.visibilityState !== "visible") {
+				app.loopID = requestAnimationFrame(frame);
+				return;
+			}
+
 			const realTime = t / 1000;
 			const realDt = realTime - app.realTime;
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -857,6 +857,7 @@ function gameFrame(ignorePause?: boolean) {
 		game.timers.forEach((t, id) => {
 			t.time -= dt();
 			if (t.time <= 0) {
+				// TODO: some timer action causes crash on FF when dt is really high, not sure why
 				t.action();
 				game.timers.delete(id);
 			}


### PR DESCRIPTION
Visibility change on different browsers are weird, sometimes causing high delta time surge which for some reason causes crash, this is a hot fix to not run the game loop at all when document is not visible, eliminating some delta time surges.