### PR TITLE
[RFC] Rename Character back to GameObj

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -187,7 +187,7 @@ interface Game {
 	loaded: boolean,
 	events: Record<string, IDList<() => void>>,
 	objEvents: Record<string, IDList<TaggedEvent>>,
-	objs: IDList<Character>,
+	objs: IDList<GameObj>,
 	timers: IDList<Timer>,
 	cam: Camera,
 	camMousePos: Vec2,
@@ -336,7 +336,7 @@ const COMP_EVENTS = new Set([
 	"inspect",
 ]);
 
-function make<T>(comps: CompList<T>): Character<T> {
+function make<T>(comps: CompList<T>): GameObj<T> {
 
 	const compStates = new Map();
 	const customState = {};
@@ -525,11 +525,11 @@ function make<T>(comps: CompList<T>): Character<T> {
 		obj.use(comp);
 	}
 
-	return obj as unknown as Character<T>;
+	return obj as unknown as GameObj<T>;
 
 }
 
-function add<T>(comps: CompList<T>): Character<T> {
+function add<T>(comps: CompList<T>): GameObj<T> {
 	const obj = make(comps);
 	obj._id = game.objs.push(obj);
 	obj.trigger("add");
@@ -537,7 +537,7 @@ function add<T>(comps: CompList<T>): Character<T> {
 	return obj;
 }
 
-function readd(obj: Character): Character {
+function readd(obj: GameObj): GameObj {
 	if (!obj.exists()) {
 		return;
 	}
@@ -547,7 +547,7 @@ function readd(obj: Character): Character {
 }
 
 // add an event to a tag
-function on(event: string, tag: Tag, cb: (obj: Character, ...args) => void): EventCanceller {
+function on(event: string, tag: Tag, cb: (obj: GameObj, ...args) => void): EventCanceller {
 	if (!game.objEvents[event]) {
 		game.objEvents[event] = new IDList();
 	}
@@ -559,7 +559,7 @@ function on(event: string, tag: Tag, cb: (obj: Character, ...args) => void): Eve
 
 // TODO: detect if is currently in another action?
 // add update event to a tag or global update
-function action(tag: Tag | (() => void), cb?: (obj: Character) => void): EventCanceller {
+function action(tag: Tag | (() => void), cb?: (obj: GameObj) => void): EventCanceller {
 	if (typeof tag === "function" && cb === undefined) {
 		return add([{ update: tag, }]).destroy;
 	} else if (typeof tag === "string") {
@@ -568,7 +568,7 @@ function action(tag: Tag | (() => void), cb?: (obj: Character) => void): EventCa
 }
 
 // add draw event to a tag or global draw
-function render(tag: Tag | (() => void), cb?: (obj: Character) => void) {
+function render(tag: Tag | (() => void), cb?: (obj: GameObj) => void) {
 	if (typeof tag === "function" && cb === undefined) {
 		return add([{ draw: tag, }]).destroy;
 	} else if (typeof tag === "string") {
@@ -580,11 +580,11 @@ function render(tag: Tag | (() => void), cb?: (obj: Character) => void) {
 function collides(
 	t1: Tag,
 	t2: Tag,
-	f: (a: Character, b: Character) => void,
+	f: (a: GameObj, b: GameObj) => void,
 ): EventCanceller {
 	const e1 = on("collide", t1, (a, b, dis) => b.is(t2) && f(a, b));
 	const e2 = on("collide", t2, (a, b, dis) => b.is(t1) && f(b, a));
-	const e3 = action(t1, (o1: Character) => {
+	const e3 = action(t1, (o1: GameObj) => {
 		if (!o1.area) {
 			throw new Error("collides() requires the object to have area() component");
 		}
@@ -596,8 +596,8 @@ function collides(
 }
 
 // add an event that runs when objs with tag t is clicked
-function clicks(t: string, f: (obj: Character) => void): EventCanceller {
-	return action(t, (o: Character) => {
+function clicks(t: string, f: (obj: GameObj) => void): EventCanceller {
+	return action(t, (o: GameObj) => {
 		if (o.isClicked()) {
 			f(o);
 		}
@@ -605,8 +605,8 @@ function clicks(t: string, f: (obj: Character) => void): EventCanceller {
 }
 
 // add an event that runs when objs with tag t is hovered
-function hovers(t: string, onHover: (obj: Character) => void, onNotHover?: (obj: Character) => void): EventCanceller {
-	return action(t, (o: Character) => {
+function hovers(t: string, onHover: (obj: GameObj) => void, onNotHover?: (obj: GameObj) => void): EventCanceller {
+	return action(t, (o: GameObj) => {
 		if (o.isHovering()) {
 			onHover(o);
 		} else {
@@ -779,7 +779,7 @@ function regDebugInput() {
 
 // TODO: cache sorted list
 // get all objects with tag
-function get(t?: string): Character[] {
+function get(t?: string): GameObj[] {
 
 	const objs = [...game.objs.values()].sort((o1, o2) => {
 
@@ -804,7 +804,7 @@ function get(t?: string): Character[] {
 }
 
 // apply a function to all objects currently in game with tag t
-function every<T>(t: string | ((obj: Character) => T), f?: (obj: Character) => T) {
+function every<T>(t: string | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
 	if (typeof t === "function" && f === undefined) {
 		return get().forEach((obj) => obj.exists() && t(obj));
 	} else if (typeof t === "string") {
@@ -813,7 +813,7 @@ function every<T>(t: string | ((obj: Character) => T), f?: (obj: Character) => T
 }
 
 // every but in reverse order
-function revery<T>(t: string | ((obj: Character) => T), f?: (obj: Character) => T) {
+function revery<T>(t: string | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
 	if (typeof t === "function" && f === undefined) {
 		return get().reverse().forEach((obj) => obj.exists() && t(obj));
 	} else if (typeof t === "string") {
@@ -822,7 +822,7 @@ function revery<T>(t: string | ((obj: Character) => T), f?: (obj: Character) => 
 }
 
 // destroy an obj
-function destroy(obj: Character) {
+function destroy(obj: GameObj) {
 	obj.destroy();
 }
 
@@ -1021,7 +1021,7 @@ function drawInspect() {
 
 }
 
-function makeCollision(target: Character<any>, dis: Vec2): Collision {
+function makeCollision(target: GameObj<any>, dis: Vec2): Collision {
 	return {
 		target: target,
 		displacement: dis,
@@ -1281,7 +1281,7 @@ function z(z: number): ZComp {
 	};
 }
 
-function follow(obj: Character, offset?: Vec2): FollowComp {
+function follow(obj: GameObj, offset?: Vec2): FollowComp {
 	return {
 		id: "follow",
 		require: [ "pos", ],
@@ -1420,7 +1420,7 @@ function area(conf: AreaCompConf = {}): AreaComp {
 			});
 		},
 
-		collides(tag: Tag, f: (o: Character, col?: Collision) => void): EventCanceller {
+		collides(tag: Tag, f: (o: GameObj, col?: Collision) => void): EventCanceller {
 			const e1 = this.action(() => this._checkCollisions(tag, f));
 			const e2 = this.on("collide", (obj, col) => obj.is(tag) && f(obj, col));
 			return () => [e1, e2].forEach((f) => f());
@@ -1435,7 +1435,7 @@ function area(conf: AreaCompConf = {}): AreaComp {
 		},
 
 		// push an obj out of another if they're overlapped
-		pushOut(obj: Character): Vec2 | null {
+		pushOut(obj: GameObj): Vec2 | null {
 
 			if (obj === this) {
 				return null;
@@ -1548,7 +1548,7 @@ function area(conf: AreaCompConf = {}): AreaComp {
 }
 
 // make the list of common render properties from the "pos", "scale", "color", "opacity", "rotate", "origin", "outline", and "shader" components of a character
-function getRenderProps(obj: Character<any>) {
+function getRenderProps(obj: GameObj<any>) {
 	return {
 		pos: obj.pos,
 		scale: obj.scale,
@@ -1919,7 +1919,7 @@ const MAX_VEL = 65536;
 function body(conf: BodyCompConf = {}): BodyComp {
 
 	let velY = 0;
-	let curPlatform: Character | null = null;
+	let curPlatform: GameObj | null = null;
 	let lastPlatformPos = null;
 	let canDouble = true;
 
@@ -1997,7 +1997,7 @@ function body(conf: BodyCompConf = {}): BodyComp {
 
 		},
 
-		curPlatform(): Character | null {
+		curPlatform(): GameObj | null {
 			return curPlatform;
 		},
 
@@ -2277,7 +2277,7 @@ function addLevel(map: string[], conf: LevelConf): Level {
 		throw new Error("Must provide level grid width & height.");
 	}
 
-	const objs: Character[] = [];
+	const objs: GameObj[] = [];
 	const offset = vec2(conf.pos || vec2(0));
 	let longRow = 0;
 
@@ -2303,7 +2303,7 @@ function addLevel(map: string[], conf: LevelConf): Level {
 			);
 		},
 
-		spawn(sym: string, ...args): Character {
+		spawn(sym: string, ...args): GameObj {
 
 			const p = vec2(...args);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,10 +93,10 @@ interface KaboomCtx {
 	 *     friend.hurt();
 	 * });
 	 *
-	 * // check out #Character for stuff that exists for all game objects, independent of its components.
+	 * // check out #GameObj for stuff that exists for all game objects, independent of its components.
 	 * ```
 	 */
-	add<T>(comps: CompList<T>): Character<T>,
+	add<T>(comps: CompList<T>): GameObj<T>,
 	/**
 	 * Get a list of all game objs with certain tag.
 	 *
@@ -109,7 +109,7 @@ interface KaboomCtx {
 	 * const allObjs = get();
 	 * ```
 	 */
-	get(tag?: Tag): Character[],
+	get(tag?: Tag): GameObj[],
 	/**
 	 * Run callback on every game obj with certain tag.
 	 *
@@ -122,13 +122,13 @@ interface KaboomCtx {
 	 * every((obj) => {});
 	 * ```
 	 */
-	every<T>(t: Tag, cb: (obj: Character) => T): void,
-	every<T>(cb: (obj: Character) => T): void,
+	every<T>(t: Tag, cb: (obj: GameObj) => T): void,
+	every<T>(cb: (obj: GameObj) => T): void,
 	/**
 	 * Run callback on every game obj with certain tag in reverse order.
 	 */
-	revery<T>(t: Tag, cb: (obj: Character) => T): void,
-	revery<T>(cb: (obj: Character) => T): void,
+	revery<T>(t: Tag, cb: (obj: GameObj) => T): void,
+	revery<T>(cb: (obj: GameObj) => T): void,
 	/**
 	 * Remove and re-add the game obj.
 	 *
@@ -138,7 +138,7 @@ interface KaboomCtx {
 	 * readd(froggy);
 	 * ```
 	 */
-	readd(obj: Character): Character,
+	readd(obj: GameObj): GameObj,
 	/**
 	 * Remove the game obj.
 	 *
@@ -150,7 +150,7 @@ interface KaboomCtx {
 	 * });
 	 * ```
 	 */
-	destroy(obj: Character): void,
+	destroy(obj: GameObj): void,
 	/**
 	 * Remove all game objs with certain tag.
 	 *
@@ -430,7 +430,7 @@ interface KaboomCtx {
 	/**
 	 * Follow another game obj's position.
 	 */
-	follow(obj: Character | null, offset?: Vec2): FollowComp,
+	follow(obj: GameObj | null, offset?: Vec2): FollowComp,
 	/**
 	 * Custom shader.
 	 */
@@ -528,7 +528,7 @@ interface KaboomCtx {
 	 * });
 	 * ```
 	 */
-	on(event: string, tag: Tag, cb: (obj: Character, ...args) => void): EventCanceller,
+	on(event: string, tag: Tag, cb: (obj: GameObj, ...args) => void): EventCanceller,
 	/**
 	 * Register "update" event (runs every frame) on all game objs with certain tag.
 	 *
@@ -549,12 +549,12 @@ interface KaboomCtx {
 	 * });
 	 * ```
 	 */
-	action(tag: Tag, cb: (obj: Character) => void): EventCanceller,
+	action(tag: Tag, cb: (obj: GameObj) => void): EventCanceller,
 	action(cb: () => void): EventCanceller,
 	/**
 	 * Register "draw" event (runs every frame) on all game objs with certain tag. (This is the same as `action()`, but all draw events are run after updates)
 	 */
-	render(tag: Tag, cb: (obj: Character) => void): EventCanceller,
+	render(tag: Tag, cb: (obj: GameObj) => void): EventCanceller,
 	render(cb: () => void): EventCanceller,
 	/**
 	 * Register event when 2 game objs with certain tags collides. This function spins off an action() when called, please put it at root level and never inside another action().
@@ -569,21 +569,21 @@ interface KaboomCtx {
 	collides(
 		t1: Tag,
 		t2: Tag,
-		cb: (a: Character, b: Character, col?: Collision) => void,
+		cb: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventCanceller,
 	/**
 	 * Register event when game objs with certain tags are clicked. This function spins off an action() when called, please put it at root level and never inside another action().
 	 */
 	clicks(
 		tag: Tag,
-		cb: (a: Character) => void,
+		cb: (a: GameObj) => void,
 	): EventCanceller,
 	/**
 	 * Register event when game objs with certain tags are hovered. This function spins off an action() when called, please put it at root level and never inside another action().
 	 */
 	hovers(
 		tag: Tag,
-		cb: (a: Character) => void,
+		cb: (a: GameObj) => void,
 	): EventCanceller,
 	/**
 	 * Get current mouse position (without camera transform).
@@ -1529,7 +1529,7 @@ type Key =
 /**
  * Inspect info for a character.
  */
-type CharacterInspect = Record<Tag, string | null>;
+type GameObjInspect = Record<Tag, string | null>;
 
 /**
  * Kaboom configurations.
@@ -1610,9 +1610,9 @@ type KaboomPlugin<T> = (k: KaboomCtx) => T;
 /**
  * A character in game. The basic unit of object in Kaboom. The player, a bullet, a tree, a piece of text, they're all characters!
  */
-type Character<T = any> = {
+type GameObj<T = any> = {
 	/**
-	 * Internal Character ID.
+	 * Internal GameObj ID.
 	 */
 	_id: number | null,
 	/**
@@ -1631,12 +1631,12 @@ type Character<T = any> = {
 	 * If there a certain tag on the game obj.
 	 */
 	is(tag: Tag | Tag[]): boolean;
-	// TODO: update the Character type info
+	// TODO: update the GameObj type info
 	/**
 	 * Add a component or tag.
 	 */
 	use(comp: Comp | Tag): void;
-	// TODO: update the Character type info
+	// TODO: update the GameObj type info
 	/**
 	 * Remove a tag or a component with its id.
 	 */
@@ -1664,7 +1664,7 @@ type Character<T = any> = {
 	/**
 	 * Gather debug info of all comps.
 	 */
-	inspect(): CharacterInspect;
+	inspect(): GameObjInspect;
 } & MergeComps<T>;
 
 type SceneID = string;
@@ -2327,7 +2327,7 @@ interface Comp {
 	inspect?: () => string;
 }
 
-type CharacterID = number;
+type GameObjID = number;
 
 interface PosComp extends Comp {
 	/**
@@ -2400,7 +2400,7 @@ interface ZComp extends Comp {
 
 interface FollowComp extends Comp {
 	follow: {
-		obj: Character,
+		obj: GameObj,
 		offset: Vec2,
 	},
 }
@@ -2418,7 +2418,7 @@ interface Collision {
 	/**
 	 * The game object that we collided into.
 	 */
-	target: Character,
+	target: GameObj,
 	/**
 	 * The displacement it'll need to separate us from the target.
 	 */
@@ -2488,11 +2488,11 @@ interface AreaComp extends Comp {
 	/**
 	 * If is currently colliding with another game obj.
 	 */
-	isColliding(o: Character): boolean,
+	isColliding(o: GameObj): boolean,
 	/**
 	 * If is currently touching another game obj.
 	 */
-	isTouching(o: Character): boolean,
+	isTouching(o: GameObj): boolean,
 	/**
 	 * Registers an event runs when clicked.
 	 */
@@ -2504,7 +2504,7 @@ interface AreaComp extends Comp {
 	/**
 	 * Registers an event runs when collides with another game obj with certain tag.
 	 */
-	collides(tag: Tag, f: (obj: Character, col?: Collision) => void): void,
+	collides(tag: Tag, f: (obj: GameObj, col?: Collision) => void): void,
 	/**
 	 * If has a certain point inside collider.
 	 */
@@ -2512,7 +2512,7 @@ interface AreaComp extends Comp {
 	/**
 	 * Push out from another solid game obj if currently overlapping.
 	 */
-	pushOut(obj: Character): void,
+	pushOut(obj: GameObj): void,
 	/**
 	 * Push out from all other solid game objs if currently overlapping.
 	 */
@@ -2769,7 +2769,7 @@ interface BodyComp extends Comp {
 	/**
 	 * Current platform landing on.
 	 */
-	curPlatform(): Character | null,
+	curPlatform(): GameObj | null,
 	/**
 	 * If currently landing on a platform.
 	 */
@@ -2911,8 +2911,8 @@ interface LevelConf {
 interface Level {
 	getPos(p: Vec2): Vec2,
 	getPos(x: number, y: number): Vec2,
-	spawn(sym: string, p: Vec2): Character,
-	spawn(sym: string, x: number, y: number): Character,
+	spawn(sym: string, p: Vec2): GameObj,
+	spawn(sym: string, x: number, y: number): GameObj,
 	width(): number,
 	height(): number,
 	gridWidth(): number,


### PR DESCRIPTION
Renamed type name `GameObj` to `Character` several weeks ago cuz I thought it's more descriptive, but often times I found `GameObj` more versatile. Not too sure here.