### PR TITLE
Rename djump to doubleJump

### DIFF
--- a/demo/doublejump.js
+++ b/demo/doublejump.js
@@ -116,7 +116,7 @@ scene("game", () => {
 	});
 
 	// spin on double jump
-	bean.on("djump", () => {
+	bean.on("doubleJump", () => {
 		bean.spin();
 	});
 
@@ -128,7 +128,7 @@ scene("game", () => {
 	});
 
 	keyPress("space", () => {
-		bean.djump();
+		bean.doubleJump();
 	});
 
 	// both keys will trigger

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2017,13 +2017,13 @@ function body(conf: BodyCompConf = {}): BodyComp {
 			velY = -force || -this.jumpForce;
 		},
 
-		djump(force: number) {
+		doubleJump(force: number) {
 			if (this.grounded()) {
 				this.jump(force);
 			} else if (canDouble) {
 				canDouble = false;
 				this.jump(force);
-				this.trigger("djump");
+				this.trigger("doubleJump");
 			}
 		},
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2800,7 +2800,7 @@ interface BodyComp extends Comp {
 	/**
 	 * Performs double jump (the initial jump only happens if player is grounded).
 	 */
-	djump(f?: number): void,
+	doubleJump(f?: number): void,
 }
 
 interface BodyCompConf {


### PR DESCRIPTION
`djump()` is a function that initiates jump only when grounded, and can initiate a double jump once while in mid air. It's unlikely people will know what this does by the name. We better go for explicitness and make this change?