### PR TITLE
Don't get gamepads since we're not using yet

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -426,8 +426,6 @@ function appInit(gconf: AppConf = {}): App {
 
 			app.skipTime = false;
 
-			const gamepads = navigator.getGamepads();
-
 			f();
 
 			for (const k in app.keyStates) {


### PR DESCRIPTION
Remove the code to get gamepad since we're not using it yet, and it's throwing error on platforms that don't have gamepad support.