### PR TITLE
Remove browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
 	"homepage": "https://kaboomjs.com/",
 	"repository": "github:replit/kaboom",
 	"author": "tga <tga@space55.xyz>",
-	"browser": "./dist/kaboom.js",
 	"main": "./dist/kaboom.cjs",
 	"module": "./dist/kaboom.mjs",
 	"types": "./dist/kaboom.d.ts",


### PR DESCRIPTION
According to `this spec`(https://github.com/defunctzombie/package-browser-field-spec), the `"browser"` field is for packages that have different behaviors on browser / non-browser to specify the file that a bundler should use when bundling for browser context. Currently we're misusing this field to point to `dist/kaboom.js` gives the `kaboom` global variable and not using any module system to export anything, causing some bundlers who prioritize `"browser"` field like parcel to not work with modulinge. Should fix #75 