### PR TITLE
Add ability to record videos of the game

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2582,6 +2582,59 @@ const ctx: KaboomCtx = {
 	DOWN: vec2(0, 1),
 	// dom
 	canvas: app.canvas,
+
+	record: (frameRate = 25) => {
+		const stream = app.canvas.captureStream(frameRate);
+
+		// Breaks the recording right now
+		// audio
+		// 	.ctx
+		// 	.createMediaStreamDestination()
+		// 	.stream
+		// 	.getAudioTracks().forEach((track) => {
+		// 		stream.addTrack(track)
+		// 	})
+
+		const mediaRecorder = new MediaRecorder(stream);
+		const recordedChunks = [];
+		mediaRecorder.ondataavailable = e => {
+			if(e.data.size > 0){
+					recordedChunks.push(e.data);
+			}
+		};
+		mediaRecorder.start();
+
+		return {
+			pause: () => {
+				mediaRecorder.pause();
+			},
+			resume: () => {
+				mediaRecorder.resume();
+			},
+			download: (filename: string = 'kaboom.mp4') => {
+				mediaRecorder.stop();
+
+				// Chunks might need a tick to flush
+				setTimeout(() => {
+					const blob = new Blob(recordedChunks, {
+						type: 'video/mp4'
+					});
+					const url = URL.createObjectURL(blob);
+
+					const a = document.createElement('a');
+					document.body.appendChild(a);
+					a.setAttribute('style', 'display: none');
+					a.href = url;
+					a.download = filename;
+					a.click();
+
+					// cleanup
+					URL.revokeObjectURL(url);
+					recordedChunks.length = 0;
+				}, 0)
+			}
+		};
+	}
 };
 
 plug(kaboomPlugin);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1504,6 +1504,23 @@ interface KaboomCtx {
 	 */
 	plug<T>(plugin: KaboomPlugin<T>): void,
 	/**
+	 * Records a video of the game returns a handle
+	 * to control the recording and download it.
+	 * No support for audio recording currenlty
+	 */
+	record(frameRate?: number): {
+		/** pauses the recording */
+		pause(): void;
+		/** resumes the recording */
+		resume(): void;
+		/**
+		 * stops the recording and downloads the file
+		 * trying to resume after downloading will lead
+		 * to an error
+		 */
+		download(filename?: string): void;
+	},
+	/**
 	 * All chars in ASCII.
 	 */
 	ASCII_CHARS: string,


### PR DESCRIPTION
@seflless suggested this feature on twitter.

This PR adds a way to record videos and download them programatically, we may look into exposing built-in UI elements for this in the future but wanted to keep scope small.

I couldn't get audio to work, so I just left it at video. If there's requests for audio, I can look into it.

I added a `record` function which I documented in the code.

N.B. we should add prettier and eslint to the repo, I had format things by hand :eyes:. We should also consider adding some testing to parts of the framework.