### PR TITLE
Allow number as scale

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1527,7 +1527,7 @@ function area(opt: AreaCompOpt = {}): AreaComp {
 				throw new Error("failed to get area dimension");
 			}
 
-			const scale = (this.scale ?? vec2(1)).scale(this.area.scale);
+			const scale = vec2(this.scale ?? 1).scale(this.area.scale);
 
 			w *= scale.x;
 			h *= scale.y;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2651,7 +2651,7 @@ interface PosComp extends Comp {
 }
 
 interface ScaleComp extends Comp {
-	scale: Vec2,
+	scale: Vec2 | number,
 	scaleTo(s: number): void,
 	scaleTo(s: Vec2): void,
 	scaleTo(sx: number, sy: number): void,


### PR DESCRIPTION
#341 

I think from an interface perspective we should allow people just `obj.scale = 2` instead of having to `obj.scale = vec2(2)` every time, not sure if it'll cause more confusion that their `.scale` type is not 100% predictable? Maybe it's fine if we never mutate the `.scale` ourself and let users think "`.scale` will be the type that you last assigned to"? 
Or maybe I overthought