### PR TITLE
[site] Enable type drawer for type docs

### DIFF
--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -95,7 +95,7 @@ Play with it yourself or check out the examples in the [Playground](/play)!
 								id={name}
 								key={name}
 								name={name}
-								typeref={(name) => setShowType(name)}
+								typeref={setShowType}
 							/>
 						)) }
 					</View>
@@ -109,7 +109,7 @@ Play with it yourself or check out the examples in the [Playground](/play)!
 					id={name}
 					key={name}
 					name={name}
-					typeref={(name) => setShowType(name)}
+					typeref={setShowType}
 				/>
 			}
 		})}
@@ -129,7 +129,7 @@ Play with it yourself or check out the examples in the [Playground](/play)!
 			{ showType &&
 				<Doc
 					name={showType}
-					typeref={(name) => setShowType(name)}
+					typeref={setShowType}
 				/>
 			}
 		</Drawer>


### PR DESCRIPTION
Enable open type drawer when click on type names in the type section in the doc, also a minor change to get rid of a pointless boolean state and just use the `string | null` for its purpose.