### PR TITLE
Remove redundant jsdoc when generating types for global functions

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -124,10 +124,6 @@ function buildTypes() {
 				if (!mem.name || dups.has(mem.name)) {
 					continue;
 				}
-				if (mem.jsDoc) {
-					// TODO: what is jsDoc when it has multiple members?
-					dts += `\t/**\n\t * ${mem.jsDoc[0].comment}\n\t */\n`;
-				}
 				if (overwrites.has(mem.name)) {
 					dts += "\t// @ts-ignore\n";
 				}


### PR DESCRIPTION
Kaboom uses `script/build.js` to generate global function definitions from `KaboomCtx` to something like this:
```ts
declare global {
	const add: KaboomCtx["add"];
	const get: KaboomCtx["get"];
	const every: KaboomCtx["every"];
}
```
but it's redundant to generate docs on these entries as they'll be referred from their origins in the `KaboomCtx` interface