### PR TITLE
Pass timeslice to mediaRecorder.start()

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2625,7 +2625,7 @@ function record(frameRate = 30): Recording {
 		}
 	};
 
-	recorder.start();
+	recorder.start(100);
 
 	return {
 


### PR DESCRIPTION
It doesn't work on FF without the argument (it specifies the frequency in ms of triggering `ondataavailable`, by default it'll record into a single big blog and pass to `ondataavailable` once when it stops)

100 is kinda an arbitrary value (taken from [this example](https://github.com/webrtc/samples/blob/e2ceae1de3dc01b83eca7cdffc2774cef4dacd1b/src/content/capture/canvas-record/js/main.js#L70))

Reference: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start)