### PR TITLE
Disable audio in recording for now due to bug

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2614,7 +2614,8 @@ function record(frameRate = 30): Recording {
 	const audioStream = audioDest.stream;
 	const [firstAudioTrack] = audioStream.getAudioTracks();
 
-// 	stream.addTrack(firstAudioTrack);
+	// TODO: Enabling audio results in empty video if no audio received
+	// stream.addTrack(firstAudioTrack);
 
 	const recorder = new MediaRecorder(stream);
 	const chunks = [];


### PR DESCRIPTION
Enabling audio results in empty video if no audio data is received (can try on a demo and don't trigger a sound). Turning this off until a fix.