### PR TITLE
Support all mouse buttons

### DIFF
--- a/demo/burp.js
+++ b/demo/burp.js
@@ -1,3 +1,3 @@
 kaboom({ burp: true });
 add([text("press b")]);
-onMouseClick(burp);
+onClick(burp);

--- a/demo/eatbomb.js
+++ b/demo/eatbomb.js
@@ -144,7 +144,7 @@ scene("lose", (score) => {
 
 	// go back to game with space is pressed
 	onKeyPress("space", () => go("start"));
-	onMouseClick(() => go("start"));
+	onClick(() => go("start"));
 
 });
 

--- a/demo/flappy.js
+++ b/demo/flappy.js
@@ -50,7 +50,7 @@ scene("game", () => {
 	});
 
 	// mobile
-	onMouseClick(() => {
+	onClick(() => {
 		bean.jump(JUMP_FORCE);
 		play("wooosh");
 	});
@@ -147,7 +147,7 @@ scene("lose", (score) => {
 
 	// go back to game with space is pressed
 	onKeyPress("space", () => go("game"));
-	onMouseClick(() => go("game"));
+	onClick(() => go("game"));
 
 });
 

--- a/demo/out.js
+++ b/demo/out.js
@@ -40,7 +40,7 @@ function shoot() {
 }
 
 onKeyPress("space", shoot);
-onMouseClick(shoot);
+onClick(shoot);
 
 onUpdate("bean", (m) => {
 	m.move(m.dir.scale(SPEED));

--- a/demo/pointclick.js
+++ b/demo/pointclick.js
@@ -16,6 +16,6 @@ player.onUpdate(() => {
 	player.moveTo(dest, 480);
 });
 
-onMouseClick(() => {
+onClick(() => {
 	dest = mousePos();
 });

--- a/demo/runner.js
+++ b/demo/runner.js
@@ -41,7 +41,7 @@ scene("game", () => {
 
 	// jump when user press space
 	onKeyPress("space", jump);
-	onMouseClick(jump);
+	onClick(jump);
 
 	function spawnTree() {
 
@@ -109,7 +109,7 @@ scene("lose", (score) => {
 
 	// go back to game with space is pressed
 	onKeyPress("space", () => go("game"));
-	onMouseClick(() => go("game"));
+	onClick(() => go("game"));
 
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -830,9 +830,9 @@ export interface KaboomCtx {
 	 */
 	charInput: KaboomCtx["onCharInput"],
 	/**
-	 * @deprecated Use onMouseClick() instead.
+	 * @deprecated Use onClick() or onMousePress() instead.
 	 */
-	mouseClick: KaboomCtx["onMouseClick"],
+	mouseClick: KaboomCtx["onMousePress"],
 	/**
 	 * @deprecated Use onMouseRelease() instead.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -655,14 +655,17 @@ export interface KaboomCtx {
 		cb: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventCanceller,
 	/**
-	 * Registers an event that runs when game objs with certain tags are clicked. This function spins off an onUpdate() when called, please put it at root level and never inside another onUpdate().
+	 * Registers an event that runs when game objs with certain tags are clicked.
 	 *
 	 * @since v2000.1.0
 	 */
-	onClick(
-		tag: Tag,
-		cb: (a: GameObj) => void,
-	): EventCanceller,
+	onClick(tag: Tag, cb: (a: GameObj) => void): EventCanceller,
+	/**
+	 * Registers an event that runs when users clicks.
+	 *
+	 * @since v2000.1.0
+	 */
+	onClick(cb: () => void): EventCanceller,
 	/**
 	 * Registers an event that runs when game objs with certain tags are hovered. This function spins off an onUpdate() when called, please put it at root level and never inside another onUpdate().
 	 *
@@ -742,19 +745,22 @@ export interface KaboomCtx {
 	 *
 	 * @since v2000.1.0
 	 */
-	onMouseDown(cb: (pos: Vec2) => void): EventCanceller,
+	onMouseDown(action: (pos: Vec2) => void): EventCanceller,
+	onMouseDown(button: MouseButton, action: (pos: Vec2) => void): EventCanceller,
 	/**
 	 * Registers an event that runs when user clicks mouse.
 	 *
 	 * @since v2000.1.0
 	 */
-	onMouseClick(cb: (pos: Vec2) => void): EventCanceller,
+	onMousePress(action: (pos: Vec2) => void): EventCanceller,
+	onMousePress(button: MouseButton, action: (pos: Vec2) => void): EventCanceller,
 	/**
 	 * Registers an event that runs when user releases mouse.
 	 *
 	 * @since v2000.1.0
 	 */
-	onMouseRelease(cb: (pos: Vec2) => void): EventCanceller,
+	onMouseRelease(action: (pos: Vec2) => void): EventCanceller,
+	onMouseRelease(button: MouseButton, action: (pos: Vec2) => void): EventCanceller,
 	/**
 	 * Registers an event that runs whenever user move the mouse.
 	 *
@@ -1132,23 +1138,23 @@ export interface KaboomCtx {
 	 */
 	isKeyReleased(k?: Key): boolean,
 	/**
-	 * If certain mouse is currently down.
+	 * If a mouse button is currently down.
 	 *
 	 * @since v2000.1.0
 	 */
-	isMouseDown(): boolean,
+	isMouseDown(button?: MouseButton): boolean,
 	/**
-	 * If mouse is just clicked last frame.
+	 * If a mouse button is just clicked last frame.
 	 *
 	 * @since v2000.1.0
 	 */
-	isMouseClicked(): boolean,
+	isMousePressed(button?: MouseButton): boolean,
 	/**
-	 * If mouse is just released last frame.
+	 * If a mouse button is just released last frame.
 	 *
 	 * @since v2000.1.0
 	 */
-	isMouseReleased(): boolean,
+	isMouseReleased(button?: MouseButton): boolean,
 	/**
 	 * If mouse moved last frame.
 	 *
@@ -1789,6 +1795,14 @@ export type Key =
 	| "z" | "x" | "c" | "v" | "b" | "n" | "m" | "," | "." | "/"
 	| "backspace" | "enter" | "tab" | "space" | " "
 	| "left" | "right" | "up" | "down"
+	;
+
+export type MouseButton =
+	| "left"
+	| "right"
+	| "middle"
+	| "back"
+	| "forward"
 	;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -655,7 +655,7 @@ export interface KaboomCtx {
 		cb: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventCanceller,
 	/**
-	 * Registers an event that runs when game objs with certain tags and area() component are clicked.
+	 * Registers an event that runs when game objs with certain tags are clicked (also required to have the area() component).
 	 *
 	 * @since v2000.1.0
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -655,7 +655,7 @@ export interface KaboomCtx {
 		cb: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventCanceller,
 	/**
-	 * Registers an event that runs when game objs with certain tags are clicked.
+	 * Registers an event that runs when game objs with certain tags and area() component are clicked.
 	 *
 	 * @since v2000.1.0
 	 */


### PR DESCRIPTION
- Support adding the first argument to `onMouseXXX` to specify which button to listen to
```js
onMousePress("right", showMyMenu)
```
- Renamed `onMouseClick` to `onMousePress` to share a similar naming style like `onKeyPress`, support `onClick` without the first `tag` argument to catch all moue click events. Removed `onMouseClick` in favor of `onMousePress` or `onClick`
```js
// before
onMouseClick(dragPlayer);
// after
onClick(dragPlayer);
```