### PR TITLE
Don't special case for hover event on touch device

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1309,11 +1309,7 @@ function area(opt: AreaCompOpt = {}): AreaComp {
 
 		isHovering() {
 			const mpos = this.fixed ? mousePos() : mouseWorldPos();
-			if (app.isTouch) {
-				return app.isMouseDown() && this.hasPoint(mpos);
-			} else {
-				return this.hasPoint(mpos);
-			}
+			return this.hasPoint(mpos);
 		},
 
 		isColliding(other) {


### PR DESCRIPTION
#375 

On touch devices `mousePos` is updated on touch anyway, so `isMouseDown()` is kinda an no-op