### PR TITLE
Support multiple tags on get() and every()

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -889,7 +889,7 @@ function enterBurpMode() {
 
 // TODO: cache sorted list
 // get all objects with tag
-function get(t?: string): GameObj[] {
+function get(t?: Tag | Tag[]): GameObj[] {
 
 	const objs = [...game.objs.values()].sort((o1, o2) => {
 
@@ -914,19 +914,19 @@ function get(t?: string): GameObj[] {
 }
 
 // apply a function to all objects currently in game with tag t
-function every<T>(t: string | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
+function every<T>(t: Tag | Tag[] | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
 	if (typeof t === "function" && f === undefined) {
 		return get().forEach((obj) => obj.exists() && t(obj));
-	} else if (typeof t === "string") {
+	} else if (typeof t === "string" || Array.isArray(t)) {
 		return get(t).forEach((obj) => obj.exists() && f(obj));
 	}
 }
 
 // every but in reverse order
-function revery<T>(t: string | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
+function revery<T>(t: Tag | Tag[] | ((obj: GameObj) => T), f?: (obj: GameObj) => T) {
 	if (typeof t === "function" && f === undefined) {
 		return get().reverse().forEach((obj) => obj.exists() && t(obj));
-	} else if (typeof t === "string") {
+	} else if (typeof t === "string" || Array.isArray(t)) {
 		return get(t).reverse().forEach((obj) => obj.exists() && f(obj));
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export interface KaboomCtx {
 	 * const allObjs = get();
 	 * ```
 	 */
-	get(tag?: Tag): GameObj[],
+	get(tag?: Tag | Tag[]): GameObj[],
 	/**
 	 * Run callback on every game obj with certain tag.
 	 *
@@ -117,7 +117,7 @@ export interface KaboomCtx {
 	 * every("fruit", destroy);
 	 * ```
 	 */
-	every<T>(t: Tag, action: (obj: GameObj) => T): void,
+	every<T>(tag: Tag | Tag[], action: (obj: GameObj) => T): void,
 	/**
 	 * Run callback on every game obj.
 	 *
@@ -130,7 +130,7 @@ export interface KaboomCtx {
 	/**
 	 * Run callback on every game obj with certain tag in reverse order.
 	 */
-	revery<T>(t: Tag, action: (obj: GameObj) => T): void,
+	revery<T>(tag: Tag | Tag[], action: (obj: GameObj) => T): void,
 	/**
 	 * Run callback on every game obj in reverse order.
 	 */
@@ -1942,7 +1942,7 @@ export interface GameObjRaw {
 	 */
 	exists(): boolean;
 	/**
-	 * If there a certain tag on the game obj.
+	 * If there's a certain tag on the game obj.
 	 */
 	is(tag: Tag | Tag[]): boolean;
 	// TODO: update the GameObj type info

--- a/src/types.ts
+++ b/src/types.ts
@@ -1942,7 +1942,7 @@ export interface GameObjRaw {
 	 */
 	exists(): boolean;
 	/**
-	 * If there's a certain tag on the game obj.
+	 * If there's certain tag(s) on the game obj.
 	 */
 	is(tag: Tag | Tag[]): boolean;
 	// TODO: update the GameObj type info


### PR DESCRIPTION
#386

`GameObj#is()` always supported checking for multiple tags, it makes sense to support multiple tags for `get()` and `every()` too