### PR TITLE
Expose formatText() and drawFormattedText()

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -115,7 +115,7 @@ type Gfx = {
 	): GfxFont,
 	drawTexture(opt: DrawTextureOpt),
 	drawText(opt: DrawTextOpt2),
-	drawFmtText(ftext: FormattedText),
+	drawFormattedText(ftext: FormattedText),
 	drawRect(opt: DrawRectOpt),
 	drawLine(opt: DrawLineOpt),
 	drawLines(opt: DrawLinesOpt),
@@ -124,7 +124,7 @@ type Gfx = {
 	drawEllipse(opt: DrawEllipseOpt),
 	drawPolygon(opt: DrawPolygonOpt),
 	drawUVQuad(opt: DrawUVQuadOpt),
-	fmtText(opt: DrawTextOpt2): FormattedText,
+	formatText(opt: DrawTextOpt2): FormattedText,
 	frameStart(),
 	frameEnd(),
 	pushTransform(): void,
@@ -1005,10 +1005,10 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 	}
 
 	// format text and return a list of chars with their calculated position
-	function fmtText(opt: DrawTextOpt2): FormattedText {
+	function formatText(opt: DrawTextOpt2): FormattedText {
 
 		if (opt.text === undefined) {
-			throw new Error("fmtText() requires property \"text\".");
+			throw new Error("formatText() requires property \"text\".");
 		}
 
 		const font = opt.font;
@@ -1126,11 +1126,11 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 	}
 
 	function drawText(opt: DrawTextOpt2) {
-		drawFmtText(fmtText(opt));
+		drawFormattedText(formatText(opt));
 	}
 
 	// TODO: rotation
-	function drawFmtText(ftext: FormattedText) {
+	function drawFormattedText(ftext: FormattedText) {
 		for (const ch of ftext.chars) {
 			drawUVQuad({
 				tex: ch.tex,
@@ -1216,7 +1216,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		makeFont,
 		drawTexture,
 		drawText,
-		drawFmtText,
+		drawFormattedText,
 		drawRect,
 		drawLine,
 		drawLines,
@@ -1225,7 +1225,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		drawEllipse,
 		drawPolygon,
 		drawUVQuad,
-		fmtText,
+		formatText,
 		frameStart,
 		frameEnd,
 		pushTranslate,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -248,13 +248,35 @@ function drawSprite(opt: DrawSpriteOpt) {
 
 // wrapper around gfx.drawText to integrate with font assets mananger / default font
 function drawText(opt: DrawTextOpt) {
-	// @ts-ignore
-	const fid = opt.font ?? DEF_FONT;
-	const font = assets.fonts[fid];
+	const font = (() => {
+		if (opt.font) {
+			return typeof opt.font === "string" ? assets.fonts[opt.font] : opt.font;
+		} else {
+			return assets.fonts[DEF_FONT];
+		}
+	})();
 	if (!font) {
-		throw new Error(`font not found: ${fid}`);
+		throw new Error(`font not found: ${opt.font}`);
 	}
 	gfx.drawText({
+		...opt,
+		font: font,
+	});
+}
+
+// wrapper around gfx.drawText to integrate with font assets mananger / default font
+function formatText(opt: DrawTextOpt) {
+	const font = (() => {
+		if (opt.font) {
+			return typeof opt.font === "string" ? assets.fonts[opt.font] : opt.font;
+		} else {
+			return assets.fonts[DEF_FONT];
+		}
+	})();
+	if (!font) {
+		throw new Error(`font not found: ${opt.font}`);
+	}
+	return gfx.formatText({
 		...opt,
 		font: font,
 	});
@@ -1766,7 +1788,7 @@ function text(t: string, opt: TextCompOpt = {}): TextComp {
 			throw new Error(`font not found: "${name}"`);
 		}
 
-		const ftext = gfx.fmtText({
+		const ftext = gfx.formatText({
 			...getRenderProps(this),
 			text: this.text + "",
 			size: this.textSize,
@@ -1796,7 +1818,7 @@ function text(t: string, opt: TextCompOpt = {}): TextComp {
 		},
 
 		draw() {
-			gfx.drawFmtText(update.call(this));
+			gfx.drawFormattedText(update.call(this));
 		},
 
 	};
@@ -2689,6 +2711,7 @@ const ctx: KaboomCtx = {
 	// raw draw
 	drawSprite,
 	drawText,
+	formatText,
 	// TODO: wrap these to use assets lib for the "shader" prop
 	drawRect: gfx.drawRect,
 	drawLine: gfx.drawLine,
@@ -2698,6 +2721,7 @@ const ctx: KaboomCtx = {
 	drawEllipse: gfx.drawEllipse,
 	drawUVQuad: gfx.drawUVQuad,
 	drawPolygon: gfx.drawPolygon,
+	drawFormattedText: gfx.drawFormattedText,
 	pushTransform: gfx.pushTransform,
 	popTransform: gfx.popTransform,
 	pushTranslate: gfx.pushTranslate,
@@ -2867,7 +2891,7 @@ function drawDebug() {
 			const s = gfx.scale();
 			const pad = vec2(6).scale(1 / s);
 
-			const ftxt = gfx.fmtText({
+			const ftxt = gfx.formatText({
 				text: txt,
 				font: font,
 				size: 16 / s,
@@ -2897,7 +2921,7 @@ function drawDebug() {
 				opacity: 0.8,
 			});
 
-			gfx.drawFmtText(ftxt);
+			gfx.drawFormattedText(ftxt);
 			gfx.popTransform();
 
 		}
@@ -3016,7 +3040,7 @@ function drawDebug() {
 		const pad = 8;
 
 		// format text first to get text size
-		const ftxt = gfx.fmtText({
+		const ftxt = gfx.formatText({
 			text: debug.timeScale.toFixed(1),
 			font: assets.fonts[DBG_FONT],
 			size: 16,
@@ -3048,7 +3072,7 @@ function drawDebug() {
 		}
 
 		// text
-		gfx.drawFmtText(ftxt);
+		gfx.drawFormattedText(ftxt);
 
 		gfx.popTransform();
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -230,17 +230,11 @@ function findAsset<T>(src: string | T, lib: Record<string, T>, def?: string): T 
 
 // wrapper around gfx.drawTexture to integrate with sprite assets mananger / frame anim
 function drawSprite(opt: DrawSpriteOpt) {
-	if (!opt.sprite) {
-		throw new Error(`drawSprite() requires property "sprite"`);
-	}
+	if (!opt.sprite) throw new Error(`drawSprite() requires property "sprite"`);
 	const spr = findAsset(opt.sprite, assets.sprites);
-	if (!spr) {
-		throw new Error(`sprite not found: "${opt.sprite}"`);
-	}
+	if (!spr) throw new Error(`sprite not found: "${opt.sprite}"`);
 	const q = spr.frames[opt.frame ?? 0];
-	if (!q) {
-		throw new Error(`frame not found: ${opt.frame ?? 0}`);
-	}
+	if (!q) throw new Error(`frame not found: ${opt.frame ?? 0}`);
 	gfx.drawTexture({
 		...opt,
 		tex: spr.tex,
@@ -251,9 +245,7 @@ function drawSprite(opt: DrawSpriteOpt) {
 // wrapper around gfx.drawText to integrate with font assets mananger / default font
 function drawText(opt: DrawTextOpt) {
 	const font = findAsset(opt.font, assets.fonts, DEF_FONT);
-	if (!font) {
-		throw new Error(`font not found: ${opt.font}`);
-	}
+	if (!font) throw new Error(`font not found: ${opt.font}`);
 	gfx.drawText({
 		...opt,
 		font: font,
@@ -263,9 +255,7 @@ function drawText(opt: DrawTextOpt) {
 // wrapper around gfx.formatText to integrate with font assets mananger / default font
 function formatText(opt: DrawTextOpt) {
 	const font = findAsset(opt.font, assets.fonts, DEF_FONT);
-	if (!font) {
-		throw new Error(`font not found: ${opt.font}`);
-	}
+	if (!font) throw new Error(`font not found: ${opt.font}`);
 	return gfx.formatText({
 		...opt,
 		font: font,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -220,18 +220,20 @@ function mouseWorldPos(): Vec2 {
 	return game.camMousePos;
 }
 
+function findAsset<T>(src: string | T, lib: Record<string, T>, def?: string): T | undefined {
+	if (src) {
+		return typeof src === "string" ? lib[src] : src;
+	} else if (def) {
+		return lib[def];
+	}
+}
+
 // wrapper around gfx.drawTexture to integrate with sprite assets mananger / frame anim
 function drawSprite(opt: DrawSpriteOpt) {
 	if (!opt.sprite) {
 		throw new Error(`drawSprite() requires property "sprite"`);
 	}
-	const spr = (() => {
-		if (typeof opt.sprite === "string") {
-			return assets.sprites[opt.sprite];
-		} else {
-			return opt.sprite;
-		}
-	})();
+	const spr = findAsset(opt.sprite, assets.sprites);
 	if (!spr) {
 		throw new Error(`sprite not found: "${opt.sprite}"`);
 	}
@@ -248,13 +250,7 @@ function drawSprite(opt: DrawSpriteOpt) {
 
 // wrapper around gfx.drawText to integrate with font assets mananger / default font
 function drawText(opt: DrawTextOpt) {
-	const font = (() => {
-		if (opt.font) {
-			return typeof opt.font === "string" ? assets.fonts[opt.font] : opt.font;
-		} else {
-			return assets.fonts[DEF_FONT];
-		}
-	})();
+	const font = findAsset(opt.font, assets.fonts, DEF_FONT);
 	if (!font) {
 		throw new Error(`font not found: ${opt.font}`);
 	}
@@ -264,15 +260,9 @@ function drawText(opt: DrawTextOpt) {
 	});
 }
 
-// wrapper around gfx.drawText to integrate with font assets mananger / default font
+// wrapper around gfx.formatText to integrate with font assets mananger / default font
 function formatText(opt: DrawTextOpt) {
-	const font = (() => {
-		if (opt.font) {
-			return typeof opt.font === "string" ? assets.fonts[opt.font] : opt.font;
-		} else {
-			return assets.fonts[DEF_FONT];
-		}
-	})();
+	const font = findAsset(opt.font, assets.fonts, DEF_FONT);
 	if (!font) {
 		throw new Error(`font not found: ${opt.font}`);
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1840,6 +1840,25 @@ export interface KaboomCtx {
 	 */
 	drawUVQuad(options: DrawUVQuadOpt): void,
 	/**
+	 * Draw a piece of formatted text from formatText().
+	 *
+	 * @example
+	 * ```js
+	 * // text background
+	 * const txt = formatText({
+	 *     text: "oh hi",
+	 * })
+	 *
+	 * drawRect({
+	 *     width: txt.width,
+	 *     height: txt.height,
+	 * })
+	 *
+	 * drawFormattedText(txt)
+	 * ```
+	 */
+	drawFormattedText(text: FormattedText): void,
+	/**
 	 * Push current transform matrix to the transform stack.
 	 *
 	 * @example
@@ -1889,6 +1908,25 @@ export interface KaboomCtx {
 	 * Rotate all subsequent draws.
 	 */
 	pushRotate(angle: number): void,
+	/**
+	 * Format a piece of text without drawing (for getting dimensions, etc).
+	 *
+	 * @example
+	 * ```js
+	 * // text background
+	 * const txt = formatText({
+	 *     text: "oh hi",
+	 * })
+	 *
+	 * drawRect({
+	 *     width: txt.width,
+	 *     height: txt.height,
+	 * })
+	 *
+	 * drawFormattedText(txt)
+	 * ```
+	 */
+	formatText(options: DrawTextOpt): FormattedText,
 	/**
 	 * @section Debug
 	 *
@@ -2770,7 +2808,7 @@ export type DrawTextOpt = RenderProps & {
 	/**
 	 * The name of font to use.
 	 */
-	font?: string,
+	font?: string | FontData,
 	/**
 	 * The size of text (the height of each character).
 	 */
@@ -2789,6 +2827,15 @@ export type DrawTextOpt = RenderProps & {
 	 * @since v2000.1.0
 	 */
 	transform?: (idx: number, ch: string) => CharTransform,
+}
+
+/**
+ * Formatted text with info on how and where to render each character.
+ */
+export interface FormattedText {
+	width: number,
+	height: number,
+	chars: FormattedChar[],
 }
 
 /**
@@ -2812,15 +2859,6 @@ export interface CharTransform {
 	angle?: number,
 	color?: Color,
 	opacity?: number,
-}
-
-/**
- * Formatted text with info on how and where to render each character.
- */
-export interface FormattedText {
-	width: number,
-	height: number,
-	chars: FormattedChar[],
 }
 
 export type Cursor =


### PR DESCRIPTION
The main use case is to get the size of the text without rendering it. It's used internally in various places to draw text backgrounds, nice to expose.

And renamed from previously internal `fmtText()` to `formatText()`, `drawFmtText()` to `drawFormattedText()`