### PR TITLE
Fix addLevel() doc markdown break

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1664,7 +1664,7 @@ export interface KaboomCtx {
 	 *     "           $$         =   $",
 	 *     "  %      ====         =   $",
 	 *     "                      =    ",
-	 *     "       ^^      = >    =   @",
+	 *     "       ^^      = >    =   &",
 	 *     "===========================",
 	 * ], {
 	 *     // define the size of each block


### PR DESCRIPTION
For some reason the sequence `@",` at that position breaks the markdown render