### PR TITLE
enterState check fail fix

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2153,7 +2153,7 @@ function state(initState: string, stateList?: string[]): StateComp {
 		id: "state",
 		state: initState,
 		enterState(state: string, ...args) {
-			if (stateList && !stateList[state]) {
+			if (stateList && !stateList.includes(state)) {
 				throw new Error(`State not found: ${state}`);
 			}
 			events[this.state].leave.forEach((action) => action());


### PR DESCRIPTION
The states are an array of strings, but the comparison is done as if it were a dictionary.
I believe the code should be: if (stateList && !stateList.includes(state))
which seems more sensible to me.