### PR TITLE
(feature) Implement temporary culling option in cleanup comp

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1278,7 +1278,7 @@ function move(direction: number | Vec2, speed: number): MoveComp {
 	};
 }
 
-function cleanup(time: number = 0): CleanupComp {
+function cleanup(time: number = 0, cull: boolean = false, cullOffset: Vec2 = vec2(0, 0)): CleanupComp {
 	let timer = 0;
 	return {
 		id: "cleanup",
@@ -1288,12 +1288,27 @@ function cleanup(time: number = 0): CleanupComp {
 				p1: vec2(0, 0),
 				p2: vec2(width(), height()),
 			}
+
+			if (cull) {
+				screenRect.p1.x -= cullOffset.x
+				screenRect.p1.y -= cullOffset.y
+				screenRect.p2.x += cullOffset.x
+				screenRect.p2.y += cullOffset.y
+			}
+
 			if (testAreaRect(this.screenArea(), screenRect)) {
 				timer = 0;
+				if (cull) {
+					this.hidden = false
+				}
 			} else {
 				timer += dt();
 				if (timer >= time) {
-					this.destroy();
+					if (cull) {
+						this.hidden = true
+					} else {
+						this.destroy();
+					}
 				}
 			}
 		},

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,7 +450,7 @@ export interface KaboomCtx {
 	 * ])
 	 * ```
 	 */
-	cleanup(time?: number): CleanupComp,
+	cleanup(time?: number, cull?: boolean, cullOffset?: Vec2): CleanupComp,
 	/**
 	 * Follow another game obj's position.
 	 */


### PR DESCRIPTION
I'm not entirely sure if this one is desirable since kaboom don't seem to aim to be a solution for massive game worlds etc, but I needed this in my project and seemed easy enough to achieve, so...