### PR TITLE
Add transition guard to state()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - added `formatText()` and `drawFormattedText()`
 - added `charSpacing` and `lineSpacing` in `TextCompOpt` and `DrawTextOpt`
+- added optional `transitions` argument in `state()` to define allowed transitions
+- added `StateComp#onStateTransition` to register event for specific transitions
 
 ### v2000.1.6
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2165,56 +2165,71 @@ function state(
 		events[state][event].forEach((action) => action(...args));
 	}
 
-	function checkTransition(from: string, to: string) {
-		if (!transitions?.[from]) {
-			return
-		}
-		const available = typeof transitions[from] === "string"
-			? [transitions[from]]
-			: transitions[from] as string[];
-		if (!available.includes(to)) {
-			throw new Error(`Cannot transition state from "${from}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`);
-		}
-	}
-
 	return {
+
 		id: "state",
 		state: initState,
+
 		enterState(state: string, ...args) {
+
 			if (stateList && !stateList.includes(state)) {
 				throw new Error(`State not found: ${state}`);
 			}
+
 			const oldState = this.state;
-			checkTransition(oldState, state);
+
+			// check if the transition is legal, if transition graph is defined
+			if (!transitions?.[oldState]) {
+				return;
+			}
+
+			const available = typeof transitions[oldState] === "string"
+				? [transitions[oldState]]
+				: transitions[oldState] as string[];
+
+			if (!available.includes(state)) {
+				throw new Error(`Cannot transition state from "${oldState}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`);
+			}
+
 			trigger("leave", oldState, ...args);
 			this.state = state;
 			trigger("enter", state, ...args);
 			trigger("enter", `${oldState} -> ${state}`, ...args);
+
 		},
+
 		onStateTransition(from: string, to: string, action: () => void) {
 			on("enter", `${from} -> ${to}`, action);
 		},
+
 		onStateEnter(state: string, action: () => void) {
 			on("enter", state, action);
 		},
+
 		onStateUpdate(state: string, action: () => void) {
 			on("update", state, action);
 		},
+
 		onStateDraw(state: string, action: () => void) {
 			on("draw", state, action);
 		},
+
 		onStateLeave(state: string, action: () => void) {
 			on("leave", state, action);
 		},
+
 		update() {
 			trigger("update", this.state);
 		},
+
 		draw() {
 			trigger("draw", this.state);
 		},
+
 		inspect() {
 			return this.state;
 		},
+
 	};
 
 }

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2130,7 +2130,11 @@ function lifespan(time: number, opt: LifespanCompOpt = {}): LifespanComp {
 	};
 }
 
-function state(initState: string, stateList?: string[]): StateComp {
+function state(
+	initState: string,
+	stateList?: string[],
+	transitions?: Record<string, string[]>,
+): StateComp {
 
 	if (!initState) {
 		throw new Error("state() requires an initial state");
@@ -2165,6 +2169,9 @@ function state(initState: string, stateList?: string[]): StateComp {
 		enterState(state: string, ...args) {
 			if (stateList && !stateList.includes(state)) {
 				throw new Error(`State not found: ${state}`);
+			}
+			if (transitions?.[this.state] && !transitions[this.state].includes(state)) {
+				throw new Error(`Cannot transition state from "${this.state}" to "${state}". Available transitions: ${transitions[this.state].map((s) => `"${s}"`).join(", ")}`);
 			}
 			trigger("leave", this.state, ...args);
 			this.state = state;

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2163,6 +2163,18 @@ function state(
 		events[state][event].forEach((action) => action(...args));
 	}
 
+	function checkTransition(from: string, to: string) {
+		if (!transitions?.[from]) {
+			return
+		}
+		const available = typeof transitions[from] === "string"
+			? [transitions[from]]
+			: transitions[from] as string[];
+		if (!available.includes(to)) {
+			throw new Error(`Cannot transition state from "${from}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`);
+		}
+	}
+
 	return {
 		id: "state",
 		state: initState,
@@ -2170,15 +2182,8 @@ function state(
 			if (stateList && !stateList.includes(state)) {
 				throw new Error(`State not found: ${state}`);
 			}
-			if (transitions?.[this.state]) {
-				const available = typeof transitions[this.state] === "string"
-					? [transitions[this.state]]
-					: transitions[this.state] as string[];
-				if (!available.includes(state)) {
-					throw new Error(`Cannot transition state from "${this.state}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`);
-				}
-			}
 			const oldState = this.state;
+			checkTransition(oldState, state);
 			trigger("leave", oldState, ...args);
 			this.state = state;
 			trigger("enter", state, ...args);

--- a/src/types.ts
+++ b/src/types.ts
@@ -575,7 +575,11 @@ export interface KaboomCtx {
 	 * })
 	 * ```
 	 */
-	state(initialState: string, stateList?: string[]): StateComp,
+	state(
+		initialState: string,
+		stateList?: string[],
+		transitions?: Record<string, string[]>,
+	): StateComp,
 	/**
 	 * Register an event on all game objs with certain tag.
 	 *

--- a/src/types.ts
+++ b/src/types.ts
@@ -604,8 +604,8 @@ export interface KaboomCtx {
 	 */
 	state(
 		initialState: string,
-		stateList?: string[],
-		transitions?: Record<string, string | string[]>,
+		stateList: string[],
+		transitions: Record<string, string | string[]>,
 	): StateComp,
 	/**
 	 * Register an event on all game objs with certain tag.

--- a/src/types.ts
+++ b/src/types.ts
@@ -578,7 +578,7 @@ export interface KaboomCtx {
 	state(
 		initialState: string,
 		stateList?: string[],
-		transitions?: Record<string, string[]>,
+		transitions?: Record<string, string | string[]>,
 	): StateComp,
 	/**
 	 * Register an event on all game objs with certain tag.
@@ -3787,6 +3787,10 @@ export interface StateComp extends Comp {
 	 * Enter a state, trigger onStateLeave for previous state and onStateEnter for the new State state.
 	 */
 	enterState: (state: string, ...args) => void,
+	/**
+	 * Register event that runs once when a specific state transition happens. Accepts arguments passed from `enterState(name, ...args)`.
+	 */
+	onStateTransition(from: string, to: string, action: () => void),
 	/**
 	 * Register event that runs once when enters a specific state. Accepts arguments passed from `enterState(name, ...args)`.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -578,6 +578,33 @@ export interface KaboomCtx {
 	state(
 		initialState: string,
 		stateList?: string[],
+	): StateComp,
+	/**
+	 * state() with pre-defined transitions.
+	 *
+	 * @since v2000.2
+	 *
+	 * @example
+	 * ```js
+	 * const enemy = add([
+	 *     pos(80, 100),
+	 *     sprite("robot"),
+	 *     state("idle", ["idle", "attack", "move"], {
+	 *         "idle": "attack",
+	 *         "attack": "move",
+	 *         "move": [ "idle", "attack" ],
+	 *     }),
+	 * ])
+	 *
+	 * // this callback will only run once when enter "attack" state from "idle"
+	 * enemy.onStateTransition("idle", "attack", () => {
+	 *     checkHit(enemy, player)
+	 * })
+	 * ```
+	 */
+	state(
+		initialState: string,
+		stateList?: string[],
 		transitions?: Record<string, string | string[]>,
 	): StateComp,
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -3789,6 +3789,8 @@ export interface StateComp extends Comp {
 	enterState: (state: string, ...args) => void,
 	/**
 	 * Register event that runs once when a specific state transition happens. Accepts arguments passed from `enterState(name, ...args)`.
+	 *
+	 * @since v2000.2
 	 */
 	onStateTransition(from: string, to: string, action: () => void),
 	/**


### PR DESCRIPTION
As proposed in [this comment](https://github.com/replit/kaboom/pull/346#pullrequestreview-789795171)

```js
const s = state("move", [ "idle", "attack", "move", ], {
    "idle": [ "move", "attack" ],
    "attack": "idle",
    "move": "attack",
})

// define event for specific transitions
s.onStateTransition("move", "attack", throwFeces)
```