### PR TITLE
[RFC] Automatically run onStateEnter() event for initial state

### DIFF
--- a/demo/ai.js
+++ b/demo/ai.js
@@ -68,9 +68,6 @@ enemy.onStateUpdate("move", () => {
 	enemy.move(dir.scale(ENEMY_SPEED))
 })
 
-// Have to manually call enterState() to trigger the onStateEnter("move") event we defined above.
-enemy.enterState("move")
-
 // Taking a bullet makes us disappear
 player.onCollide("bullet", (bullet) => {
 	destroy(bullet)

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2137,6 +2137,7 @@ function state(initState: string, stateList?: string[]): StateComp {
 	}
 
 	const events = {};
+	let initializing = true;
 
 	function initStateHook(state: string) {
 		if (!events[state]) {
@@ -2166,12 +2167,16 @@ function state(initState: string, stateList?: string[]): StateComp {
 			if (stateList && !stateList.includes(state)) {
 				throw new Error(`State not found: ${state}`);
 			}
+			initializing = false;
 			trigger("leave", this.state, ...args);
 			this.state = state;
 			trigger("enter", this.state, ...args);
 		},
 		onStateEnter(state: string, action: () => void) {
 			on("enter", state, action);
+			if (initializing && state === initState) {
+				action();
+			}
 		},
 		onStateUpdate(state: string, action: () => void) {
 			on("update", state, action);
@@ -2183,6 +2188,7 @@ function state(initState: string, stateList?: string[]): StateComp {
 			on("leave", state, action);
 		},
 		update() {
+			initializing = false;
 			trigger("update", this.state);
 		},
 		draw() {


### PR DESCRIPTION
Before:

```js
state("idle", [ "idle", "attack", "move" ])

obj.onStateEnter("idle", () => {
    wait(1, () => obj.enterState("attack"))
})

// have to manually call enterState("idle") to trigger the onStateEnter() event defined above
obj.enterState("idle")
```

After:

```js
state("idle", [ "idle", "attack", "move" ])

// this will call the action immediately since our initial state is "idle"
obj.onStateEnter("idle", () => {
    wait(1, () => obj.enterState("attack"))
})
```


But consider this case:

```js
state("idle", [ "idle", "attack", "move" ])

obj.onStateEnter("attack", () => {
    wait(0.5, () => obj.enterState("move"))
})

// this will synchronously trigger the on enter "attack" we defined above, before executing on enter "idle" we defined below which should probably be triggered first for the initial state
obj.enterState("attack")

obj.onStateEnter("idle", () => {
    wait(1, () => obj.enterState("attack"))
})
```