### PR TITLE
[RFC] Add syntax to style chunks of text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added `charSpacing` and `lineSpacing` in `TextCompOpt` and `DrawTextOpt`
 - added optional `transitions` argument in `state()` to define allowed transitions
 - added `StateComp#onStateTransition` to register event for specific transitions
+- added syntax for chunked text style `"this is a [styled].wavy text"` and `style` option in `TextCompOpt` and `DrawTextOpt` to define the styles with `CharTransformFunc`
 
 ### v2000.1.6
 

--- a/demo/text.js
+++ b/demo/text.js
@@ -89,7 +89,7 @@ onKeyDown("down", () => {
 
 // Use this syntax and style option to style chunks of text, with CharTransformFunc.
 add([
-	text("(oh hi):green this is a (styled):wavy text", {
+	text("[oh hi].green this is a [styled].wavy text", {
 		styles: {
 			"green": (idx, ch) => ({
 				color: GREEN,

--- a/demo/text.js
+++ b/demo/text.js
@@ -87,4 +87,22 @@ onKeyDown("down", () => {
 	input.textSize = curSize
 })
 
+// Use this syntax and style option to style chunks of text, with CharTransformFunc.
+add([
+	text("(oh hi):green this is a (styled):wavy text", {
+		styles: {
+			"green": (idx, ch) => ({
+				color: GREEN,
+			}),
+			"wavy": (idx, ch) => ({
+				color: BLUE,
+				pos: vec2(0, wave(-4, 4, time() * 4 + idx * 0.5)),
+			}),
+		},
+	}),
+	pos(pad, height() - pad),
+	origin("botleft"),
+	scale(0.5),
+])
+
 // Check out https://kaboomjs.com#TextComp for everything text() offers

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1030,7 +1030,6 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 
 		// put each styled char index into a map for easy access by index later
 		for (const match of opt.text.matchAll(TEXT_STYLE_RE)) {
-			// TODO: match.index refers to the index in original string
 			for (
 				let i = match.index - idxOffset;
 				i <= match.index + match.groups.text.length;

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1025,10 +1025,11 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		}
 
 		const charStyleMap = {};
+		// get the text without the styling syntax
 		const renderText = opt.text.replace(TEXT_STYLE_RE, "$1");
 		let idxOffset = 0;
 
-		// put each styled char index into a map for easy access by index later
+		// put each styled char index into a map for easy access later when iterating each char
 		for (const match of opt.text.matchAll(TEXT_STYLE_RE)) {
 			for (
 				let i = match.index - idxOffset;

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1139,14 +1139,18 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 						angle: 0,
 					}
 					if (opt.transform) {
-						const tr = opt.transform(idx, char) ?? {};
-						applyCharTransform(fchar, tr);
+						const tr = opt.transform(idx, char);
+						if (tr) {
+							applyCharTransform(fchar, tr);
+						}
 					}
 					if (charStyleMap[idx]) {
 						const { styles, idx: localIdx } = charStyleMap[idx];
 						for (const style of styles) {
-							const tr = opt.styles[style](localIdx, char) ?? {};
-							applyCharTransform(fchar, tr);
+							const tr = opt.styles[style](localIdx, char);
+							if (tr) {
+								applyCharTransform(fchar, tr);
+							}
 						}
 					}
 					fchars.push(fchar);

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1015,7 +1015,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		if (tr.opacity) fchar.opacity *= tr.opacity;
 	}
 
-	const TEXT_STYLE_RE = /\((?<text>[^\)]+)\):(?<style>\w+)/g;
+	const TEXT_STYLE_RE = /\((?<text>[^\)]*)\):(?<style>\w+)/g;
 
 	// format text and return a list of chars with their calculated position
 	function formatText(opt: DrawTextOpt2): FormattedText {

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1019,14 +1019,20 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 
 	const TEXT_STYLE_RE = /\[(?<text>[^\]]*)\]\.(?<style>[\w\.]+)+/g;
 
-	function compileStyledText(text: string) {
+	function compileStyledText(text: string): {
+		charStyleMap: Record<number, {
+			localIdx: number,
+			styles: string[],
+		}>,
+		text: string,
+	} {
 
 		const charStyleMap = {};
 		// get the text without the styling syntax
 		const renderText = text.replace(TEXT_STYLE_RE, "$1");
 		let idxOffset = 0;
 
-		// put each styled char index into a map for easy access later when iterating each char
+		// put each styled char index into a map for easy access when iterating each char
 		for (const match of text.matchAll(TEXT_STYLE_RE)) {
 			const styles = match.groups.style.split(".");
 			for (
@@ -1035,11 +1041,11 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 				i++
 			) {
 				charStyleMap[i] = {
-					idx: i - match.index,
+					localIdx: i - match.index,
 					styles: styles,
 				};
 			}
-			// omit "(", ")", ":" and the style text in the format string when calculating index
+			// omit "[", "]", "." and the style text in the format string when calculating index
 			idxOffset += 3 + match.groups.style.length;
 		}
 
@@ -1157,7 +1163,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 						}
 					}
 					if (charStyleMap[idx]) {
-						const { styles, idx: localIdx } = charStyleMap[idx];
+						const { styles, localIdx } = charStyleMap[idx];
 						for (const style of styles) {
 							const tr = opt.styles[style](localIdx, char);
 							if (tr) {

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1019,20 +1019,15 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 
 	const TEXT_STYLE_RE = /\[(?<text>[^\]]*)\]\.(?<style>[\w\.]+)+/g;
 
-	// format text and return a list of chars with their calculated position
-	function formatText(opt: DrawTextOpt2): FormattedText {
-
-		if (opt.text === undefined) {
-			throw new Error("formatText() requires property \"text\".");
-		}
+	function compileStyledText(text: string) {
 
 		const charStyleMap = {};
 		// get the text without the styling syntax
-		const renderText = opt.text.replace(TEXT_STYLE_RE, "$1");
+		const renderText = text.replace(TEXT_STYLE_RE, "$1");
 		let idxOffset = 0;
 
 		// put each styled char index into a map for easy access later when iterating each char
-		for (const match of opt.text.matchAll(TEXT_STYLE_RE)) {
+		for (const match of text.matchAll(TEXT_STYLE_RE)) {
 			const styles = match.groups.style.split(".");
 			for (
 				let i = match.index - idxOffset;
@@ -1048,8 +1043,23 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 			idxOffset += 3 + match.groups.style.length;
 		}
 
+		return {
+			charStyleMap: charStyleMap,
+			text: renderText,
+		};
+
+	}
+
+	// format text and return a list of chars with their calculated position
+	function formatText(opt: DrawTextOpt2): FormattedText {
+
+		if (opt.text === undefined) {
+			throw new Error("formatText() requires property \"text\".");
+		}
+
+		const { charStyleMap, text } = compileStyledText(opt.text + "");
 		const font = opt.font;
-		const chars = (renderText + "").split("");
+		const chars = text.split("");
 		const gw = font.qw * font.tex.width;
 		const gh = font.qh * font.tex.height;
 		const size = opt.size || gh;

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1775,6 +1775,7 @@ function text(t: string, opt: TextCompOpt = {}): TextComp {
 			font: font,
 			width: opt.width,
 			transform: opt.transform,
+			styles: opt.styles,
 		});
 
 		this.width = ftext.width / (this.scale?.x || 1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2842,7 +2842,13 @@ export type DrawTextOpt = RenderProps & {
 	 *
 	 * @since v2000.1
 	 */
-	transform?: (idx: number, ch: string) => CharTransform,
+	transform?: CharTransformFunc,
+	/**
+	 * Stylesheet for styled chunks, in the syntax of "here comes a (styled):wavy word".
+	 *
+	 * @since v2000.2
+	 */
+	styles?: Record<string, CharTransformFunc>,
 }
 
 /**
@@ -2866,8 +2872,9 @@ export interface FormattedChar {
 	angle: number,
 	color: Color,
 	opacity: number,
-	origin: string,
 }
+
+export type CharTransformFunc = (idx: number, ch: string) => CharTransform;
 
 export interface CharTransform {
 	pos?: Vec2,
@@ -3464,8 +3471,16 @@ export interface TextCompOpt {
 	width?: number,
 	/**
 	 * Transform the pos, scale, rotation or color for each character based on the index or char.
+	 *
+	 * @since v2000.1
 	 */
-	transform?: (idx: number, ch: string) => CharTransform,
+	transform?: CharTransformFunc,
+	/**
+	 * Stylesheet for styled chunks, in the syntax of "here comes a (styled):wavy word".
+	 *
+	 * @since v2000.2
+	 */
+	styles?: Record<string, CharTransformFunc>,
 }
 
 export interface RectCompOpt {


### PR DESCRIPTION
Added a special syntax to enable style chunks of text
```js
drawText({
	text: "(oh hi):green this is a (styled):wavy text",
	styles: {
		"green": (idx, ch) => ({
			color: GREEN,
		}),
		"wavy": (idx, ch) => ({
			color: BLUE,
			pos: vec2(0, wave(-4, 4, time() * 4 + idx * 0.5)),
		}),
	},
})
```
<img width="644" alt="1637183374" src="https://user-images.githubusercontent.com/9929523/142282931-ebbeb679-7620-413d-a58c-639411017db7.png">

Another idea is to use [BBCode](https://en.wikipedia.org/wiki/BBCode) syntax (implemented in #432)

```js
"[green]oh hi[/green] this is a [wavy]styled[/wavy] text"
```