### PR TITLE
Rename dir() to vec2FromAngle()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added optional `transitions` argument in `state()` to define allowed transitions
 - added `StateComp#onStateTransition` to register event for specific transitions
 - added syntax for chunked text style `"this is a [styled].wavy text"` and `style` option in `TextCompOpt` and `DrawTextOpt` to define the styles with `CharTransformFunc`
+- deprecated `dir()` in favor of `vec2FromAngle()`
 
 ### v2000.1.6
 

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -4,7 +4,6 @@ import {
 	quad,
 	rgb,
 	mat4,
-	dir,
 	deg2rad,
 	isVec2,
 	isVec3,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -34,7 +34,7 @@ import {
 	testCirclePoint,
 	testRectPolygon,
 	minkDiff,
-	dir,
+	vec2FromAngle,
 	deg2rad,
 	rad2deg,
 	isVec2,
@@ -1267,8 +1267,8 @@ function follow(obj: GameObj, offset?: Vec2): FollowComp {
 	};
 }
 
-function move(direction: number | Vec2, speed: number): MoveComp {
-	const d = typeof direction === "number" ? dir(direction) : direction.unit();
+function move(dir: number | Vec2, speed: number): MoveComp {
+	const d = typeof dir === "number" ? vec2FromAngle(dir) : dir.unit();
 	return {
 		id: "move",
 		require: [ "pos", ],
@@ -2709,7 +2709,8 @@ const ctx: KaboomCtx = {
 	randi,
 	randSeed,
 	vec2,
-	dir,
+	vec2FromAngle,
+	dir: vec2FromAngle,
 	rgb,
 	hsl2rgb,
 	quad,
@@ -2835,7 +2836,7 @@ function drawFrame() {
 	// calculate camera matrix
 	const size = vec2(width(), height());
 	const cam = game.cam;
-	const shake = dir(rand(0, 360)).scale(cam.shake);
+	const shake = vec2FromAngle(rand(0, 360)).scale(cam.shake);
 
 	cam.shake = lerp(cam.shake, 0, 5 * dt());
 	game.camMatrix = mat4()

--- a/src/math.ts
+++ b/src/math.ts
@@ -133,7 +133,7 @@ function vec2(...args): Vec2 {
 	};
 }
 
-function dir(deg: number): Vec2 {
+function vec2FromAngle(deg: number): Vec2 {
 	const angle = deg2rad(deg);
 	return vec2(Math.cos(angle), Math.sin(angle));
 }
@@ -808,7 +808,7 @@ export {
 	testCirclePoint,
 	testRectPolygon,
 	minkDiff,
-	dir,
+	vec2FromAngle,
 	isVec2,
 	isVec3,
 	isColor,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1631,15 +1631,19 @@ export interface KaboomCtx {
 		h2: number,
 	): number,
 	/**
-	 * Get directional vector from an angle
+	 * Get directional vector from an angle.
 	 *
 	 * @example
 	 * ```js
-	 * // move towards 80 deg direction at SPEED
+	 * // move towards 60 deg direction at SPEED pixels per second
 	 * player.onUpdate(() => {
-	 *     player.move(dir(80).scale(SPEED))
+	 *     player.move(vec2FromAngle(60).scale(SPEED))
 	 * })
 	 * ```
+	 */
+	vec2FromAngle(deg: number): Vec2,
+	/**
+	 * @deprecated v2000.2 Use vec2FromAngle instead.
 	 */
 	dir(deg: number): Vec2,
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1635,9 +1635,9 @@ export interface KaboomCtx {
 	 *
 	 * @example
 	 * ```js
-	 * // move towards 60 deg direction at SPEED pixels per second
+	 * // move toward bottom right in 45 degrees
 	 * player.onUpdate(() => {
-	 *     player.move(vec2FromAngle(60).scale(SPEED))
+	 *     player.move(vec2FromAngle(45).scale(SPEED))
 	 * })
 	 * ```
 	 */


### PR DESCRIPTION
`dir()` is unintuitive and takes a very generic name spot