### PR TITLE
Fix text style parsing weirdness

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -1016,6 +1016,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		if (tr.opacity) fchar.opacity *= tr.opacity;
 	}
 
+	// TODO: escape
 	const TEXT_STYLE_RE = /\[(?<text>[^\]]*)\]\.(?<style>[\w\.]+)+/g;
 
 	function compileStyledText(text: string): {
@@ -1034,13 +1035,14 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		// put each styled char index into a map for easy access when iterating each char
 		for (const match of text.matchAll(TEXT_STYLE_RE)) {
 			const styles = match.groups.style.split(".");
+			const origIdx = match.index - idxOffset;
 			for (
-				let i = match.index - idxOffset;
-				i <= match.index + match.groups.text.length;
+				let i = origIdx;
+				i < match.index + match.groups.text.length;
 				i++
 			) {
 				charStyleMap[i] = {
-					localIdx: i - match.index,
+					localIdx: i - origIdx,
 					styles: styles,
 				};
 			}
@@ -1089,6 +1091,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 				th += ch;
 				curX = 0;
 				lastSpace = null;
+				curLine.push(char);
 				flines.push(curLine);
 				curLine = [];
 			} else if ((opt.width ? (curX + cw > opt.width) : false)) {
@@ -1143,7 +1146,6 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 				const qpos = font.map[char];
 				const x = cn * cw;
 				const y = ln * ch;
-				idx += 1;
 				if (qpos) {
 					const fchar: FormattedChar = {
 						tex: font.tex,
@@ -1172,6 +1174,7 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 					}
 					fchars.push(fchar);
 				}
+				idx += 1;
 			});
 		});
 


### PR DESCRIPTION
Character index tracking got out of sync due to
- the first index wrongfully starts with `1`
- styled chunk character local index is not taking consideration of index offset
- `\n` got omitted when forming formatted char list, however the style char index is recording the position with those `\n`s