### PR TITLE
docs: Filter section names by search

### DIFF
--- a/site/comps/Nav.tsx
+++ b/site/comps/Nav.tsx
@@ -130,6 +130,8 @@ const Index: React.FC = () => {
 
 };
 
+type SectionTuple = [string, string[]]
+
 interface IndexContentProps {
 	shrink: () => void,
 }
@@ -139,6 +141,16 @@ const IndexContent: React.FC<IndexContentProps> = ({
 }) => {
 
 	const [ query, setQuery ] = React.useState("");
+
+	const filteredSections = doc.sections.reduce((acc: SectionTuple[], cur) => {
+		const filteredEntries = cur.entries
+			.filter(name => query ? name.match(new RegExp(query, "i")) : true);
+
+		// Exclude sections that have no matching entries.
+		return filteredEntries.length > 0
+			? acc.concat([[cur.name, filteredEntries]])
+			: acc;
+	}, [])
 
 	return <>
 
@@ -165,14 +177,11 @@ const IndexContent: React.FC<IndexContentProps> = ({
 
 			<Input value={query} onChange={setQuery} placeholder="Search in doc" />
 
-			{ doc.sections.map((sec) => {
-
-				const entries = sec.entries
-					.filter((name) => query ? name.match(new RegExp(query, "i")) : true);
+			{ filteredSections.map(([sectionName, entries]) => {
 
 				return (
-					<View stretchX gap={1} key={sec.name}>
-						<Text size="big" color={3}>{sec.name}</Text>
+					<View stretchX gap={1} key={sectionName}>
+						<Text size="big" color={3}>{sectionName}</Text>
 							<View>
 								{ entries.map((name) => {
 


### PR DESCRIPTION
The documentation navbar can be difficult to use on laptops or smaller
resolution devices due to needing to scroll down the list of section
names after a search query. Instead, filter the section names out of the
list if they don't have any matching entries.

## Before

![image](https://user-images.githubusercontent.com/3778552/143059163-95645204-885c-49c6-8ed4-46ca2577cc8e.png)


## After

![image](https://user-images.githubusercontent.com/3778552/143059227-b63a3b06-1aaa-46b1-b7b6-d06ecd045ba1.png)

![image](https://user-images.githubusercontent.com/3778552/143059295-74dcf5d5-e625-4316-891f-93c95c18071d.png)



