### PR TITLE
Build on npm script "prepare" instead of "prepack"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"build": "node scripts/build.js",
 		"check": "tsc --noEmit",
 		"test": "",
-		"prepack": "npm run build"
+		"prepare": "npm run build"
 	},
 	"devDependencies": {
 		"esbuild": "0.14.2",


### PR DESCRIPTION
Currently kaboom doesn't work with npm if you install with git repo `npm install replit/kaboom`

"prepare" runs before "prepack", which also runs when package is installed via github where `dist/` is `.gitignore`-ed