### PR TITLE
[RFC] `weight` -> `gravityScale`

### DIFF
--- a/demo/platformer.js
+++ b/demo/platformer.js
@@ -286,11 +286,11 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
 	})
 
 	onKeyPress("down", () => {
-		player.weight = 3
+		player.gravityScale = 3
 	})
 
 	onKeyRelease("down", () => {
-		player.weight = 1
+		player.gravityScale = 1
 	})
 
 	onKeyPress("f", () => {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1911,7 +1911,7 @@ function body(opt: BodyCompOpt = {}): BodyComp {
 		id: "body",
 		require: [ "pos", "area", ],
 		jumpForce: opt.jumpForce ?? DEF_JUMP_FORCE,
-		weight: opt.weight ?? 1,
+		gravityScale: opt.gravityScale ?? 1,
 		solid: opt.solid ?? true,
 
 		update() {
@@ -1973,7 +1973,7 @@ function body(opt: BodyCompOpt = {}): BodyComp {
 					}
 				}
 
-				velY += gravity() * this.weight * dt();
+				velY += gravity() * this.gravityScale * dt();
 				velY = Math.min(velY, opt.maxVel ?? MAX_VEL);
 
 			}
@@ -2030,6 +2030,18 @@ function body(opt: BodyCompOpt = {}): BodyComp {
 
 		onDoubleJump(action: () => void): EventCanceller {
 			return this.on("doubleJump", action);
+		},
+
+		// TODO: not working
+		// @deprecated
+		get weight() {
+			return this.gravityScale;
+		},
+
+		// TODO: not working
+		// @deprecated
+		set weight(val: number) {
+			this.gravityScale = val;
 		},
 
 	};

--- a/src/types.ts
+++ b/src/types.ts
@@ -3726,7 +3726,7 @@ export interface BodyComp extends Comp {
 	/**
 	 * Gravity multiplier.
 	 */
-	weight: number,
+	gravityScale: number,
 	/**
 	 * Current platform landing on.
 	 */
@@ -3783,6 +3783,10 @@ export interface BodyComp extends Comp {
 	 * @deprecated v2000.1 Use isFalling() instead.
 	 */
 	falling(): boolean,
+	/**
+	 * @deprecated v2000.2 Use gravityScale instead.
+	 */
+	weight?: number,
 }
 
 export interface BodyCompOpt {
@@ -3797,11 +3801,15 @@ export interface BodyCompOpt {
 	/**
 	 * Gravity multiplier.
 	 */
-	weight?: number,
+	gravityScale?: number,
 	/**
 	 * If should not move through other solid objects.
 	 */
 	solid?: boolean,
+	/**
+	 * @deprecated v2000.2 Use gravityScale instead.
+	 */
+	weight?: number,
 }
 
 export interface Timer {


### PR DESCRIPTION
`gravityScale` seems to be a better name, since the number is literally the scale to gravity.

`weight` might be used in the future to define how much an object can push another object