### PR TITLE
Disable automatic culling

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -9,7 +9,6 @@ import {
 	isVec3,
 	isColor,
 	isMat4,
-	testRectRect,
 } from "./math";
 
 import {
@@ -480,19 +479,19 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 			flush();
 		}
 
-		const objBound = { p1: vec2(Number.MAX_VALUE), p2: vec2(-Number.MAX_VALUE)};
-		const screenBound = { p1: vec2(-1), p2: vec2(1) };
+// 		const objBound = { p1: vec2(Number.MAX_VALUE), p2: vec2(-Number.MAX_VALUE)};
+// 		const screenBound = { p1: vec2(-1), p2: vec2(1) };
 
 		for (const v of verts) {
 
-			// WebGL screen space coordinate [-1.0 ~ 1.0]
+			// normalized world space coordinate [-1.0 ~ 1.0]
 			const pt = toNDC(gfx.transform.multVec2(v.pos.xy()));
 
 			// get the bounding rectangle for the polygon
-			objBound.p1.x = Math.min(objBound.p1.x, pt.x);
-			objBound.p2.x = Math.max(objBound.p2.x, pt.x);
-			objBound.p1.y = Math.min(objBound.p1.y, pt.y);
-			objBound.p2.y = Math.max(objBound.p2.y, pt.y);
+// 			objBound.p1.x = Math.min(objBound.p1.x, pt.x);
+// 			objBound.p2.x = Math.max(objBound.p2.x, pt.x);
+// 			objBound.p1.y = Math.min(objBound.p1.y, pt.y);
+// 			objBound.p2.y = Math.max(objBound.p2.y, pt.y);
 
 			gfx.vqueue.push(
 				pt.x, pt.y, v.pos.z,
@@ -500,13 +499,6 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 				v.color.r / 255, v.color.g / 255, v.color.b / 255, v.opacity,
 			);
 
-		}
-
-		// if the object bound is totally outside, we don't render
-		if (!testRectRect(objBound, screenBound)) {
-			const num = verts.length * STRIDE;
-			gfx.vqueue.splice(gfx.vqueue.length - num, num);
-			return;
 		}
 
 		for (const i of indices) {

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -479,19 +479,10 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 			flush();
 		}
 
-// 		const objBound = { p1: vec2(Number.MAX_VALUE), p2: vec2(-Number.MAX_VALUE)};
-// 		const screenBound = { p1: vec2(-1), p2: vec2(1) };
-
 		for (const v of verts) {
 
 			// normalized world space coordinate [-1.0 ~ 1.0]
 			const pt = toNDC(gfx.transform.multVec2(v.pos.xy()));
-
-			// get the bounding rectangle for the polygon
-// 			objBound.p1.x = Math.min(objBound.p1.x, pt.x);
-// 			objBound.p2.x = Math.max(objBound.p2.x, pt.x);
-// 			objBound.p1.y = Math.min(objBound.p1.y, pt.y);
-// 			objBound.p2.y = Math.max(objBound.p2.y, pt.y);
 
 			gfx.vqueue.push(
 				pt.x, pt.y, v.pos.z,


### PR DESCRIPTION
Since #410 we're using shader uniform to apply camera instead of calculating the transformed vertices on CPU, the final vertices we calculate in `drawRaw` are world-space instead of screen-space due to this change, making the bound checking pointless if any camera transformation is involved. The direct effect is objects outside of [0, 0] - [width, height] were not rendered despite being in camera.

Should fix [this](https://github.com/replit/kaboom/pull/405#issuecomment-979701128)