### PR TITLE
docs: use proper naming convention for GitHub

### DIFF
--- a/site/comps/Nav.tsx
+++ b/site/comps/Nav.tsx
@@ -171,7 +171,7 @@ const IndexContent: React.FC<IndexContentProps> = ({
 			<View gap={0.5}>
 				<NavLink link="/play" text="PlayGround" />
 				<NavLink link="/doc/intro" text="Tutorial" />
-				<NavLink link="https://github.com/replit/kaboom" text="Github" />
+				<NavLink link="https://github.com/replit/kaboom" text="GitHub" />
 				<NavLink link="https://discord.com/invite/aQ6RuQm3TF" text="Discord" />
 			</View>
 


### PR DESCRIPTION
A tiny, yet subtle update to ensure we're using proper name convention.