### PR TITLE
Only bind webgl vertex attribs once

### DIFF
--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -247,6 +247,12 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		const vbuf = gl.createBuffer();
 
 		gl.bindBuffer(gl.ARRAY_BUFFER, vbuf);
+		gl.vertexAttribPointer(0, 3, gl.FLOAT, false, STRIDE * 4, 0);
+		gl.enableVertexAttribArray(0);
+		gl.vertexAttribPointer(1, 2, gl.FLOAT, false, STRIDE * 4, 12);
+		gl.enableVertexAttribArray(1);
+		gl.vertexAttribPointer(2, 4, gl.FLOAT, false, STRIDE * 4, 20);
+		gl.enableVertexAttribArray(2);
 		gl.bufferData(gl.ARRAY_BUFFER, QUEUE_COUNT * 4, gl.DYNAMIC_DRAW);
 		gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
@@ -389,15 +395,6 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 				gl.useProgram(null);
 			},
 
-			bindAttribs() {
-				gl.vertexAttribPointer(0, 3, gl.FLOAT, false, STRIDE * 4, 0);
-				gl.enableVertexAttribArray(0);
-				gl.vertexAttribPointer(1, 2, gl.FLOAT, false, STRIDE * 4, 12);
-				gl.enableVertexAttribArray(1);
-				gl.vertexAttribPointer(2, 4, gl.FLOAT, false, STRIDE * 4, 20);
-				gl.enableVertexAttribArray(2);
-			},
-
 			send(uniform: Uniform) {
 				this.bind();
 				for (const name in uniform) {
@@ -523,7 +520,6 @@ function gfxInit(gl: WebGLRenderingContext, gopt: GfxOpt): Gfx {
 		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, gfx.ibuf);
 		gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, new Uint16Array(gfx.iqueue));
 		gfx.curShader.bind();
-		gfx.curShader.bindAttribs();
 		gfx.curTex.bind();
 		gl.drawElements(gl.TRIANGLES, gfx.iqueue.length, gl.UNSIGNED_SHORT, 0);
 		gfx.curTex.unbind();

--- a/src/types.ts
+++ b/src/types.ts
@@ -2551,7 +2551,6 @@ export interface AudioPlay {
 export interface GfxShader {
 	bind(): void,
 	unbind(): void,
-	bindAttribs(): void,
 	send(uniform: Uniform): void,
 }
 


### PR DESCRIPTION
According to [this](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_changing_vao_attachments_vertexattribpointer_disableenablevertexattribarray) it might help performance. We're only using one vertex layout now anyway.