### PR TITLE
Don't allow children game objects yet

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -422,8 +422,6 @@ const game: Game = {
 
 function layers(list: string[], def?: string) {
 
-	deprecateMsg("layers()", "parent game object");
-
 	list.forEach((name, idx) => {
 		game.layers[name] = idx + 1;
 	});
@@ -496,6 +494,9 @@ function make<T>(comps: CompList<T>): GameObj<T> {
 		parent: null,
 
 		add<T2>(comps: CompList<T2>): GameObj<T2> {
+			if (this !== game.root) {
+				throw new Error("Children game object not supported yet");
+			}
 			const obj = make(comps);
 			obj.parent = this;
 			obj.trigger("add");
@@ -1296,7 +1297,6 @@ function origin(o: Origin | Vec2): OriginComp {
 }
 
 function layer(l: string): LayerComp {
-	deprecateMsg("layer()", "parent game object");
 	return {
 		id: "layer",
 		layer: l,

--- a/src/types.ts
+++ b/src/types.ts
@@ -363,8 +363,6 @@ export interface KaboomCtx {
 	origin(o: Origin | Vec2): OriginComp,
 	/**
 	 * Which layer this object belongs to.
-	 *
-	 * @deprecated v2000.2 Use parent game object with z() or fixed() component instead.
 	 */
 	layer(l: string): LayerComp,
 	/**
@@ -1324,8 +1322,6 @@ export interface KaboomCtx {
 	gravity(g: number): number,
 	/**
 	 * Define layers (the last one will be on top).
-	 *
-	 * @deprecated v2000.2 Use parent game object with z() or fixed() component instead.
 	 *
 	 * @example
 	 * ```js


### PR DESCRIPTION
Currently doesn't support area for children game objects yet, turning it off until the next major release. 

Also as a result don't deprecate layers yet.