### PR TITLE
fix toWorld(), deprecate mouseWorldPos()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed `onTouchEnd()` fired on `touchmove`
 - added `outview()` component to control behavior when object leaves visible area
 - deprecated `cleanup(delay?: number)` in favor of `cleanup(opt?: CleanupOpt)`
+- deprecated `mouseWorldPos()` in favor of `toWorld(mousePos())`
 
 ### v2000.1.8
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1211,7 +1211,9 @@ export interface KaboomCtx {
 	 */
 	mousePos(): Vec2,
 	/**
-	 * Get current mouse position (after camera transform)
+	 * Get current mouse position (after camera transform).
+	 *
+	 * @deprecated v2000.2 Use toWorld(mousePos()) instead.
 	 */
 	mouseWorldPos(): Vec2,
 	/**


### PR DESCRIPTION
- fix `toWorld()` to return the correct position transformed by camera
- deprecate `mouseWorldPos()` in favor of `toWorld(mousePos())`