### PR TITLE
Make some structure classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - added optional `transitions` argument in `state()` to define allowed transitions
 - added `StateComp#onStateTransition` to register event for specific transitions
 - added syntax to style a piece of text `"this is a [styled].wavy text"` and `style` option in `TextCompOpt` and `DrawTextOpt` to define the styles with `CharTransformFunc`
-- deprecated `dir()` in favor of `vec2FromAngle()`
+- deprecated `dir()` in favor of `Vec2.fromAngle()`
 - fixed `onTouchEnd()` fired on `touchmove`
 - added `outview()` component to control behavior when object leaves visible area
 - deprecated `cleanup(delay?: number)` in favor of `cleanup(opt?: CleanupOpt)`

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -210,7 +210,7 @@ function buildTypes() {
 	fs.writeFileSync(`site/doc.json`, JSON.stringify({
 		types,
 		sections,
-	}, null, 4));
+	}));
 
 	console.log(`-> site/doc.json`);
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -102,7 +102,7 @@ function buildTypes() {
 				const members = {};
 				for (const mem of v) {
 					const name = mem.name?.escapedText;
-					if (!name) {
+					if (!name || name === "toString") {
 						continue;
 					}
 					if (!members[name]) {
@@ -162,7 +162,7 @@ function buildTypes() {
 		if (stmt.name === "KaboomCtx") {
 
 			if (stmt.kind !== "InterfaceDeclaration") {
-				throw new Error("KaboomCtx has to be an interface.");
+				throw new Error("KaboomCtx must be an interface.");
 			}
 
 			for (const name in stmt.members) {
@@ -210,7 +210,7 @@ function buildTypes() {
 	fs.writeFileSync(`site/doc.json`, JSON.stringify({
 		types,
 		sections,
-	}));
+	}, null, 4));
 
 	console.log(`-> site/doc.json`);
 

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -19,8 +19,6 @@ const tasks = [
 ];
 
 process.on("SIGINT", () => {
-	tasks.forEach((t) => {
-		process.kill(-t.pid);
-	});
+	tasks.forEach((t) => process.kill(-t.pid));
 	process.exit();
 });

--- a/site/comps/Doc.tsx
+++ b/site/comps/Doc.tsx
@@ -107,7 +107,11 @@ interface TitleProps {
 }
 
 function isType(entry: any): boolean {
-	return entry.kind === "TypeAliasDeclaration" || entry.kind === "InterfaceDeclaration";
+	return [
+		"TypeAliasDeclaration",
+		"InterfaceDeclaration",
+		"ClassDeclaration",
+	].includes(entry.kind);
 }
 
 const Title: React.FC<TitleProps> = ({ data, small, children }) => (
@@ -212,11 +216,31 @@ const InterfaceDeclaration: React.FC<EntryProps> = ({ data }) => {
 	);
 };
 
+const ClassDeclaration: React.FC<EntryProps> = ({ data }) => {
+	return (
+		<View gap={2} stretchX>
+			<View gap={1} stretchX>
+				<Title data={data} />
+				<JSDoc data={data} />
+			</View>
+			{ Object.entries(data.members).map(([name, variants]: [string, any], i) =>
+				variants.map((mem: any, j: number) =>
+					<Member key={`${mem.name}-${i}-${j}`} data={mem} />
+				)
+			) }
+		</View>
+	);
+};
+
 const Member: React.FC<MemberProps> = ({ data }) => {
 	switch (data.kind) {
 		case "MethodSignature":
 			return <MethodSignature data={data} small />;
 		case "PropertySignature":
+			return <PropertySignature data={data} small />;
+		case "MethodDeclaration":
+			return <MethodSignature data={data} small />;
+		case "PropertyDeclaration":
 			return <PropertySignature data={data} small />;
 	}
 	return <></>;
@@ -238,6 +262,8 @@ const Entry: React.FC<EntryProps> = ({ data }) => {
 			return <TypeAliasDeclaration data={data} />;
 		case "InterfaceDeclaration":
 			return <InterfaceDeclaration data={data} />;
+		case "ClassDeclaration":
+			return <ClassDeclaration data={data} />;
 	}
 	return <></>;
 };

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -240,23 +240,6 @@ const PREVENT_DEFAULT_KEYS = [
 const ASCII_CHARS = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 const CP437_CHARS = " ☺☻♥♦♣♠•◘○◙♂♀♪♫☼►◄↕‼¶§▬↨↑↓→←∟↔▲▼ !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~⌂ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■";
 
-// TODO: contain in a table?
-// directions
-const LEFT = vec2(-1, 0);
-const RIGHT = vec2(1, 0);
-const UP = vec2(0, -1);
-const DOWN = vec2(0, 1);
-
-// colors
-const RED = rgb(255, 0, 0);
-const GREEN = rgb(0, 255, 0);
-const BLUE = rgb(0, 0, 255);
-const YELLOW = rgb(255, 255, 0);
-const MAGENTA = rgb(255, 0, 255);
-const CYAN = rgb(0, 255, 255);
-const WHITE = rgb(255, 255, 255);
-const BLACK = rgb(0, 0, 0);
-
 // audio gain range
 const MIN_GAIN = 0;
 const MAX_GAIN = 3;
@@ -774,7 +757,7 @@ function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1): Quad[] {
 	const qh = h / y;
 	for (let j = 0; j < y; j++) {
 		for (let i = 0; i < x; i++) {
-			frames.push(quad(
+			frames.push(new Quad(
 				dx + i * qw,
 				dy + j * qh,
 				qw,
@@ -916,7 +899,7 @@ function loadAseprite(
 					.then((data) => {
 						const size = data.meta.size;
 						sprite.frames = data.frames.map((f: any) => {
-							return quad(
+							return new Quad(
 								f.frame.x / size.w,
 								f.frame.y / size.h,
 								f.frame.w / size.w,
@@ -1474,7 +1457,7 @@ function frameStart() {
 		drawUVQuad({
 			width: width(),
 			height: height(),
-			quad: quad(
+			quad: new Quad(
 				0,
 				0,
 				width() * s.scale / BG_GRID_SIZE,
@@ -1579,7 +1562,7 @@ function drawUVQuad(opt: DrawUVQuadOpt) {
 	const h = opt.height;
 	const origin = originPt(opt.origin || DEF_ORIGIN);
 	const offset = origin.scale(vec2(w, h).scale(-0.5));
-	const q = opt.quad || quad(0, 0, 1, 1);
+	const q = opt.quad || new Quad(0, 0, 1, 1);
 	const color = opt.color || rgb(255, 255, 255);
 	const opacity = opt.opacity ?? 1;
 
@@ -1627,7 +1610,7 @@ function drawTexture(opt: DrawTextureOpt) {
 		throw new Error("drawTexture() requires property \"tex\".");
 	}
 
-	const q = opt.quad ?? quad(0, 0, 1, 1);
+	const q = opt.quad ?? new Quad(0, 0, 1, 1);
 	const w = opt.tex.width * q.w;
 	const h = opt.tex.height * q.h;
 	const scale = vec2(1);
@@ -1720,7 +1703,7 @@ function drawSprite(opt: DrawSpriteOpt) {
 	drawTexture({
 		...opt,
 		tex: spr.tex,
-		quad: q.scale(opt.quad || quad(0, 0, 1, 1)),
+		quad: q.scale(opt.quad || new Quad(0, 0, 1, 1)),
 		uniform: {
 			...opt.uniform,
 			"u_transform": opt.fixed ? new Mat4() : s.camMatrix,
@@ -1833,7 +1816,7 @@ function drawLine(opt: DrawLineOpt) {
 	].map((p) => ({
 		pos: vec3(p.x, p.y, 0),
 		uv: vec2(0),
-		color: opt.color ?? Color.white(),
+		color: opt.color ?? Color.WHITE,
 		opacity: opt.opacity ?? 1,
 	}));
 
@@ -1968,7 +1951,7 @@ function drawPolygon(opt: DrawPolygonOpt) {
 
 	if (opt.fill !== false) {
 
-		const color = opt.color ?? Color.white();
+		const color = opt.color ?? Color.WHITE;
 
 		const verts = opt.pts.map((pt) => ({
 			pos: vec3(pt.x, pt.y, 0),
@@ -2154,7 +2137,7 @@ function formatText(opt: DrawTextOpt): FormattedText {
 			if (qpos) {
 				const fchar: FormattedChar = {
 					tex: font.tex,
-					quad: quad(qpos.x, qpos.y, font.qw, font.qh),
+					quad: new Quad(qpos.x, qpos.y, font.qw, font.qh),
 					ch: char,
 					pos: vec2(pos.x + x + ox + oxl, pos.y + y + oy),
 					opacity: opt.opacity,
@@ -3802,7 +3785,7 @@ function sprite(id: string | SpriteData, opt: SpriteCompOpt = {}): SpriteComp {
 		width: 0,
 		height: 0,
 		frame: opt.frame || 0,
-		quad: opt.quad || quad(0, 0, 1, 1),
+		quad: opt.quad || new Quad(0, 0, 1, 1),
 		animSpeed: opt.animSpeed ?? 1,
 
 		load() {
@@ -5541,23 +5524,24 @@ const ctx: KaboomCtx = {
 	// char sets
 	ASCII_CHARS,
 	CP437_CHARS,
-	// dirs
-	LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	// colors
-	RED,
-	GREEN,
-	BLUE,
-	YELLOW,
-	MAGENTA,
-	CYAN,
-	WHITE,
-	BLACK,
 	// dom
 	canvas: s.canvas,
+	// misc
 	addKaboom,
+	// dirs
+	LEFT: Vec2.LEFT,
+	RIGHT: Vec2.RIGHT,
+	UP: Vec2.UP,
+	DOWN: Vec2.DOWN,
+	// colors
+	RED: Color.RED,
+	GREEN: Color.GREEN,
+	BLUE: Color.BLUE,
+	YELLOW: Color.YELLOW,
+	MAGENTA: Color.MAGENTA,
+	CYAN: Color.CYAN,
+	WHITE: Color.WHITE,
+	BLACK: Color.BLACK,
 	// deprecated
 	keyIsDown: deprecate("keyIsDown()", "isKeyDown()", isKeyDown),
 	keyIsPressed: deprecate("keyIsPressed()", "isKeyPressed()", isKeyPressed),

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1,5 +1,4 @@
 import {
-	vec2FromAngle,
 	vec2,
 	vec3,
 	Vec3,
@@ -3434,7 +3433,7 @@ function follow(obj: GameObj, offset?: Vec2): FollowComp {
 }
 
 function move(dir: number | Vec2, speed: number): MoveComp {
-	const d = typeof dir === "number" ? vec2FromAngle(dir) : dir.unit();
+	const d = typeof dir === "number" ? Vec2.fromAngle(dir) : dir.unit();
 	return {
 		id: "move",
 		require: [ "pos", ],
@@ -4886,7 +4885,7 @@ function drawFrame() {
 	// calculate camera matrix
 	const scale = vec2(-2 / width(), 2 / height());
 	const cam = s.cam;
-	const shake = vec2FromAngle(rand(0, 360)).scale(cam.shake).scale(scale);
+	const shake = Vec2.fromAngle(rand(0, 360)).scale(cam.shake).scale(scale);
 
 	cam.shake = lerp(cam.shake, 0, 5 * dt());
 	s.camMatrix = new Mat4()
@@ -5539,7 +5538,7 @@ const ctx: KaboomCtx = {
 	mouseIsClicked: deprecate("mouseIsClicked()", "isMousePressed()", isMousePressed),
 	mouseIsReleased: deprecate("mouseIsReleased()", "isMouseReleased()", isMouseReleased),
 	mouseIsMoved: deprecate("mouseIsMoved()", "isMouseMoved()", isMouseMoved),
-	dir: deprecate("dir()", "vec2FromAngle()", vec2FromAngle),
+	dir: deprecate("dir()", "Vec2.fromAngle()", Vec2.fromAngle),
 	action: deprecate("action()", "onUpdate()", onUpdate),
 	render: deprecate("render()", "onDraw()", onDraw),
 	collides: deprecate("collides()", "onCollide()", onCollide),

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1,9 +1,13 @@
 import {
+	vec2FromAngle,
 	vec2,
 	vec3,
-	Mat4,
 	Vec3,
 	Color,
+	Vec2,
+	Mat4,
+	Quad,
+	RNG,
 	quad,
 	rgb,
 	hsl2rgb,
@@ -37,10 +41,8 @@ import {
 	testCirclePoint,
 	testRectPolygon,
 	minkDiff,
-	vec2FromAngle,
 	deg2rad,
 	rad2deg,
-	isVec2,
 } from "./math";
 
 import {
@@ -81,13 +83,11 @@ import {
 	SpriteLoadOpt,
 	SpriteAtlasData,
 	FontLoadOpt,
-	Quad,
 	GfxTexData,
 	KaboomCtx,
 	KaboomOpt,
 	AudioPlay,
 	AudioPlayOpt,
-	Vec2,
 	DrawSpriteOpt,
 	DrawTextOpt,
 	GameObj,
@@ -1341,7 +1341,7 @@ function makeShader(
 				} else if (val instanceof Vec3) {
 					// @ts-ignore
 					gl.uniform3f(loc, val.x, val.y, val.z);
-				} else if (isVec2(val)) {
+				} else if (val instanceof Vec2) {
 					// @ts-ignore
 					gl.uniform2f(loc, val.x, val.y);
 				}
@@ -2599,7 +2599,7 @@ function toScreen(p: Vec2): Vec2 {
 }
 
 function toWorld(p: Vec2): Vec2 {
-	return toScreen(s.camMatrix.invert().multVec2(screen2ndc(p)));
+	return ndc2screen(s.camMatrix.invert().multVec2(screen2ndc(p)));
 }
 
 const COMP_DESC = new Set([
@@ -3567,7 +3567,7 @@ function area(opt: AreaCompOpt = {}): AreaComp {
 		},
 
 		isHovering() {
-			const mpos = this.fixed ? mousePos() : mouseWorldPos();
+			const mpos = this.fixed ? mousePos() : toWorld(mousePos());
 			return this.hasPoint(mpos);
 		},
 
@@ -5471,12 +5471,16 @@ const ctx: KaboomCtx = {
 	burp,
 	audioCtx: s.audioCtx,
 	// math
+	Vec2,
+	Color,
+	Mat4,
+	Quad,
+	RNG,
 	rng,
 	rand,
 	randi,
 	randSeed,
 	vec2,
-	vec2FromAngle,
 	rgb,
 	hsl2rgb,
 	quad,

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,8 +1,6 @@
 import {
 	Vec4,
 	Point,
-	Rect,
-	Circle,
 	Polygon,
 	Area,
 } from "./types";
@@ -270,7 +268,7 @@ export class Quad {
 	y: number = 0;
 	w: number = 1;
 	h: number = 1;
-	constructor(x: number = 0, y: number = 0, w: number = 1, h: number = 1) {
+	constructor(x: number, y: number, w: number, h: number) {
 		this.x = x;
 		this.y = y;
 		this.w = w;
@@ -818,5 +816,23 @@ export class Line {
 	constructor(p1: Vec2, p2: Vec2) {
 		this.p1 = p1;
 		this.p2 = p2;
+	}
+}
+
+export class Rect {
+	p1: Vec2;
+	p2: Vec2;
+	constructor(p1: Vec2, p2: Vec2) {
+		this.p1 = p1;
+		this.p2 = p2;
+	}
+}
+
+export class Circle {
+	center: Vec2;
+	radius: number;
+	constructor(center: Vec2, radius: number) {
+		this.center = center;
+		this.radius = radius;
 	}
 }

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,24 +1,25 @@
 import {
-	Vec2,
 	Vec4,
-	Quad,
 	Point,
 	Rect,
 	Circle,
 	Polygon,
 	Area,
-	RNG,
 } from "./types";
 
-function deg2rad(deg: number): number {
+import {
+	deprecateMsg,
+} from "./utils";
+
+export function deg2rad(deg: number): number {
 	return deg * Math.PI / 180;
 }
 
-function rad2deg(rad: number): number {
+export function rad2deg(rad: number): number {
 	return rad * 180 / Math.PI;
 }
 
-function clamp(
+export function clamp(
 	val: number,
 	min: number,
 	max: number,
@@ -29,7 +30,7 @@ function clamp(
 	return Math.min(Math.max(val, min), max);
 }
 
-function lerp(
+export function lerp(
 	a: number,
 	b: number,
 	t: number,
@@ -37,7 +38,7 @@ function lerp(
 	return a + (b - a) * t;
 }
 
-function map(
+export function map(
 	v: number,
 	l1: number,
 	h1: number,
@@ -47,7 +48,7 @@ function map(
 	return l2 + (v - l1) / (h1 - l1) * (h2 - l2);
 }
 
-function mapc(
+export function mapc(
 	v: number,
 	l1: number,
 	h1: number,
@@ -57,7 +58,69 @@ function mapc(
 	return clamp(map(v, l1, h1, l2, h2), l2, h2);
 }
 
-function vec2(...args): Vec2 {
+export class Vec2 {
+	x: number = 0;
+	y: number = 0;
+	constructor(x: number = 0, y: number = x) {
+		this.x = x;
+		this.y = y;
+	}
+	clone(): Vec2 {
+		return new Vec2(this.x, this.y);
+	}
+	add(...args): Vec2 {
+		const p2 = vec2(...args);
+		return new Vec2(this.x + p2.x, this.y + p2.y);
+	}
+	sub(...args): Vec2 {
+		const p2 = vec2(...args);
+		return new Vec2(this.x - p2.x, this.y - p2.y);
+	}
+	scale(...args): Vec2 {
+		const s = vec2(...args);
+		return new Vec2(this.x * s.x, this.y * s.y);
+	}
+	dist(...args): number {
+		const p2 = vec2(...args);
+		return Math.sqrt(
+			(this.x - p2.x) * (this.x - p2.x)
+			+ (this.y - p2.y) * (this.y - p2.y)
+		);
+	}
+	len(): number {
+		return this.dist(new Vec2(0, 0));
+	}
+	unit(): Vec2 {
+		return this.scale(1 / this.len());
+	}
+	normal(): Vec2 {
+		return new Vec2(this.y, -this.x);
+	}
+	dot(p2: Vec2): number {
+		return this.x * p2.x + this.y * p2.y;
+	}
+	angle(...args): number {
+		const p2 = vec2(...args);
+		return rad2deg(Math.atan2(this.y - p2.y, this.x - p2.x));
+	}
+	lerp(p2: Vec2, t: number): Vec2 {
+		return new Vec2(lerp(this.x, p2.x, t), lerp(this.y, p2.y, t));
+	}
+	toFixed(n: number): Vec2 {
+		return new Vec2(Number(this.x.toFixed(n)), Number(this.y.toFixed(n)));
+	}
+	eq(other: Vec2): boolean {
+		return this.x === other.x && this.y === other.y;
+	}
+	toString(): string {
+		return `(${this.x.toFixed(2)}, ${this.y.toFixed(2)})`;
+	}
+	str(): string {
+		return this.toString();
+	}
+}
+
+export function vec2(...args): Vec2 {
 
 	if (args.length === 0) {
 		return vec2(0, 0);
@@ -66,71 +129,19 @@ function vec2(...args): Vec2 {
 	if (args.length === 1) {
 		if (typeof args[0] === "number") {
 			return vec2(args[0], args[0]);
-		} else if (isVec2(args[0])) {
+		} else if (args[0] instanceof Vec2) {
 			return vec2(args[0].x, args[0].y);
 		} else if (Array.isArray(args[0]) && args[0].length === 2) {
 			return vec2.apply(null, args[0]);
 		}
 	}
 
-	return {
-		x: args[0],
-		y: args[1],
-		clone(): Vec2 {
-			return vec2(this.x, this.y);
-		},
-		add(...args): Vec2 {
-			const p2 = vec2(...args);
-			return vec2(this.x + p2.x, this.y + p2.y);
-		},
-		sub(...args): Vec2 {
-			const p2 = vec2(...args);
-			return vec2(this.x - p2.x, this.y - p2.y);
-		},
-		scale(...args): Vec2 {
-			const s = vec2(...args);
-			return vec2(this.x * s.x, this.y * s.y);
-		},
-		dist(...args): number {
-			const p2 = vec2(...args);
-			return Math.sqrt(
-				(this.x - p2.x) * (this.x - p2.x)
-				+ (this.y - p2.y) * (this.y - p2.y)
-			);
-		},
-		len(): number {
-			return this.dist(vec2(0, 0));
-		},
-		unit(): Vec2 {
-			return this.scale(1 / this.len());
-		},
-		normal(): Vec2 {
-			return vec2(this.y, -this.x);
-		},
-		dot(p2: Vec2): number {
-			return this.x * p2.x + this.y * p2.y;
-		},
-		angle(...args): number {
-			const p2 = vec2(...args);
-			return rad2deg(Math.atan2(this.y - p2.y, this.x - p2.x));
-		},
-		lerp(p2: Vec2, t: number): Vec2 {
-			return vec2(lerp(this.x, p2.x, t), lerp(this.y, p2.y, t));
-		},
-		toFixed(n: number): Vec2 {
-			return vec2(this.x.toFixed(n), this.y.toFixed(n));
-		},
-		eq(other: Vec2): boolean {
-			return this.x === other.x && this.y === other.y;
-		},
-		str(): string {
-			return `(${this.x.toFixed(2)}, ${this.y.toFixed(2)})`;
-		},
-	};
+	return new Vec2(...args);
+
 }
 
 // TODO: Vec2.fromAngle
-function vec2FromAngle(deg: number): Vec2 {
+export function vec2FromAngle(deg: number): Vec2 {
 	const angle = deg2rad(deg);
 	return vec2(Math.cos(angle), Math.sin(angle));
 }
@@ -150,13 +161,6 @@ export class Vec3 {
 }
 
 export const vec3 = (x, y, z) => new Vec3(x, y, z);
-
-function isVec2(p: any): boolean {
-	return p !== undefined
-		&& p.x !== undefined
-		&& p.y !== undefined
-		;
-}
 
 export class Color {
 
@@ -210,6 +214,7 @@ export class Color {
 	}
 
 	str(): string {
+		deprecateMsg("str()", "toString()");
 		return `(${this.r}, ${this.g}, ${this.b})`;
 	}
 
@@ -244,33 +249,61 @@ export class Color {
 
 }
 
-export const rgb = (r, g, b) => new Color(r, g, b);
+export function rgb(...args): Color {
+	if (args.length === 0) {
+		return new Color(255, 255, 255);
+	} else if (args.length === 1) {
+		if (args[0] instanceof Color) {
+			return args[0].clone();
+		} else if (Array.isArray(args[0]) && args[0].length === 3) {
+			return Color.fromArray(args[0]);
+		}
+	} else if (args.length === 3) {
+		return new Color(args[0], args[1], args[2]);
+	}
+	throw new Error(`Invalid args to rgb(): ${[...args]}`);
+}
+
 export const hsl2rgb = (h, s, l) => Color.fromHSL(h, s, l);
 
-function quad(x: number, y: number, w: number, h: number): Quad {
-	return {
-		x: x ?? 0,
-		y: y ?? 0,
-		w: w ?? 1,
-		h: h ?? 1,
-		scale(other: Quad): Quad {
-			return quad(
-				this.x + this.w * other.x,
-				this.y + this.h * other.y,
-				this.w * other.w,
-				this.h * other.h
-			);
-		},
-		clone(): Quad {
-			return quad(this.x, this.y, this.w, this.h);
-		},
-		eq(other: Quad): boolean {
-			return this.x === other.x
-				&& this.y === other.y
-				&& this.w === other.w
-				&& this.h === other.h;
-		},
-	};
+export class Quad {
+	x: number = 0;
+	y: number = 0;
+	w: number = 1;
+	h: number = 1;
+	constructor(x, y, w, h) {
+		this.x = x;
+		this.y = y;
+		this.w = w;
+		this.h = h;
+	}
+	static full() {
+		return new Quad(0, 0, 1, 1);
+	}
+	scale(other: Quad): Quad {
+		return new Quad(
+			this.x + this.w * other.x,
+			this.y + this.h * other.y,
+			this.w * other.w,
+			this.h * other.h
+		);
+	}
+	clone(): Quad {
+		return new Quad(this.x, this.y, this.w, this.h);
+	}
+	eq(other: Quad): boolean {
+		return this.x === other.x
+			&& this.y === other.y
+			&& this.w === other.w
+			&& this.h === other.h;
+	}
+	toString(): string {
+		return `quad(${this.x}, ${this.y}, ${this.w}, ${this.h})`;
+	}
+}
+
+export function quad(x: number, y: number, w: number, h: number): Quad {
+	return new Quad(x, y, w, h);
 }
 
 export class Mat4 {
@@ -470,7 +503,7 @@ export class Mat4 {
 
 }
 
-function wave(lo: number, hi: number, t: number, f = Math.sin): number {
+export function wave(lo: number, hi: number, t: number, f = Math.sin): number {
 	return lo + (f(t) + 1) / 2 * (hi - lo);
 }
 
@@ -478,78 +511,85 @@ function wave(lo: number, hi: number, t: number, f = Math.sin): number {
 const A = 1103515245;
 const C = 12345;
 const M = 2147483648;
-// TODO: let user pass seed
-const defRNG = rng(Date.now());
 
-function rng(seed: number): RNG {
-	return {
-		seed: seed,
-		gen(...args) {
-			if (args.length === 0) {
-				this.seed = (A * this.seed + C) % M;
-				return this.seed / M;
-			} else if (args.length === 1) {
-				if (typeof args[0] === "number") {
-					return this.gen(0, args[0]);
-				} else if (isVec2(args[0])) {
-					return this.gen(vec2(0, 0), args[0]);
-				} else if (args[0] instanceof Color) {
-					return this.gen(rgb(0, 0, 0), args[0]);
-				}
-			} else if (args.length === 2) {
-				if (typeof args[0] === "number" && typeof args[1] === "number") {
-					return (this.gen() * (args[1] - args[0])) + args[0];
-				} else if (isVec2(args[0]) && isVec2(args[1])) {
-					return vec2(
-						this.gen(args[0].x, args[1].x),
-						this.gen(args[0].y, args[1].y),
-					);
-				} else if (args[0] instanceof Color && args[1] instanceof Color) {
-					return rgb(
-						this.gen(args[0].r, args[1].r),
-						this.gen(args[0].g, args[1].g),
-						this.gen(args[0].b, args[1].b),
-					);
-				}
+export class RNG {
+	seed: number;
+	constructor(seed: number) {
+		this.seed = seed;
+	}
+	gen(...args) {
+		if (args.length === 0) {
+			this.seed = (A * this.seed + C) % M;
+			return this.seed / M;
+		} else if (args.length === 1) {
+			if (typeof args[0] === "number") {
+				return this.gen(0, args[0]);
+			} else if (args[0] instanceof Vec2) {
+				return this.gen(vec2(0, 0), args[0]);
+			} else if (args[0] instanceof Color) {
+				return this.gen(rgb(0, 0, 0), args[0]);
 			}
-		},
-	};
+		} else if (args.length === 2) {
+			if (typeof args[0] === "number" && typeof args[1] === "number") {
+				return (this.gen() * (args[1] - args[0])) + args[0];
+			} else if (args[0] instanceof Vec2 && args[1] instanceof Vec2) {
+				return vec2(
+					this.gen(args[0].x, args[1].x),
+					this.gen(args[0].y, args[1].y),
+				);
+			} else if (args[0] instanceof Color && args[1] instanceof Color) {
+				return rgb(
+					this.gen(args[0].r, args[1].r),
+					this.gen(args[0].g, args[1].g),
+					this.gen(args[0].b, args[1].b),
+				);
+			}
+		}
+	}
 }
 
-function randSeed(seed?: number): number {
+// TODO: let user pass seed
+const defRNG = new RNG(Date.now());
+
+export function rng(seed: number): RNG {
+	deprecateMsg("rng()", "new RNG()");
+	return new RNG(seed);
+}
+
+export function randSeed(seed?: number): number {
 	if (seed != null) {
 		defRNG.seed = seed;
 	}
 	return defRNG.seed;
 }
 
-function rand(...args) {
+export function rand(...args) {
 	// @ts-ignore
 	return defRNG.gen(...args);
 }
 
 // TODO: randi() to return 0 / 1?
-function randi(...args) {
+export function randi(...args) {
 	return Math.floor(rand(...args));
 }
 
-function chance(p: number): boolean {
+export function chance(p: number): boolean {
 	return rand() <= p;
 }
 
-function choose<T>(list: T[]): T {
+export function choose<T>(list: T[]): T {
 	return list[randi(list.length)];
 }
 
 // TODO: better name
-function testRectRect2(r1: Rect, r2: Rect): boolean {
+export function testRectRect2(r1: Rect, r2: Rect): boolean {
 	return r1.p2.x >= r2.p1.x
 		&& r1.p1.x <= r2.p2.x
 		&& r1.p2.y >= r2.p1.y
 		&& r1.p1.y <= r2.p2.y;
 }
 
-function testRectRect(r1: Rect, r2: Rect): boolean {
+export function testRectRect(r1: Rect, r2: Rect): boolean {
 	return r1.p2.x > r2.p1.x
 		&& r1.p1.x < r2.p2.x
 		&& r1.p2.y > r2.p1.y
@@ -557,7 +597,7 @@ function testRectRect(r1: Rect, r2: Rect): boolean {
 }
 
 // TODO: better name
-function testLineLineT(l1: Line, l2: Line): number | null {
+export function testLineLineT(l1: Line, l2: Line): number | null {
 
 	if ((l1.p1.x === l1.p2.x && l1.p1.y === l1.p2.y) || (l2.p1.x === l2.p2.x && l2.p1.y === l2.p2.y)) {
 		return null;
@@ -582,7 +622,7 @@ function testLineLineT(l1: Line, l2: Line): number | null {
 
 }
 
-function testLineLine(l1: Line, l2: Line): Vec2 | null {
+export function testLineLine(l1: Line, l2: Line): Vec2 | null {
 	const t = testLineLineT(l1, l2);
 	if (!t) return null;
 	return vec2(
@@ -591,7 +631,7 @@ function testLineLine(l1: Line, l2: Line): Vec2 | null {
 	);
 }
 
-function testRectLine(r: Rect, l: Line): boolean {
+export function testRectLine(r: Rect, l: Line): boolean {
 	if (testRectPoint(r, l.p1) || testRectPoint(r, l.p2)) {
 		return true;
 	}
@@ -601,22 +641,22 @@ function testRectLine(r: Rect, l: Line): boolean {
 		|| !!testLineLine(l, new Line(vec2(r.p1.x, r.p2.y), r.p1));
 }
 
-function testRectPoint2(r: Rect, pt: Point): boolean {
+export function testRectPoint2(r: Rect, pt: Point): boolean {
 	return pt.x >= r.p1.x && pt.x <= r.p2.x && pt.y >= r.p1.y && pt.y <= r.p2.y;
 }
 
-function testRectPoint(r: Rect, pt: Point): boolean {
+export function testRectPoint(r: Rect, pt: Point): boolean {
 	return pt.x > r.p1.x && pt.x < r.p2.x && pt.y > r.p1.y && pt.y < r.p2.y;
 }
 
-function testRectCircle(r: Rect, c: Circle): boolean {
+export function testRectCircle(r: Rect, c: Circle): boolean {
 	const nx = Math.max(r.p1.x, Math.min(c.center.x, r.p2.x));
 	const ny = Math.max(r.p1.y, Math.min(c.center.y, r.p2.y));
 	const nearestPoint = vec2(nx, ny);
 	return nearestPoint.dist(c.center) <= c.radius;
 }
 
-function testRectPolygon(r: Rect, p: Polygon): boolean {
+export function testRectPolygon(r: Rect, p: Polygon): boolean {
 	return testPolygonPolygon(p, [
 		r.p1,
 		vec2(r.p2.x, r.p1.y),
@@ -626,16 +666,16 @@ function testRectPolygon(r: Rect, p: Polygon): boolean {
 }
 
 // TODO
-function testLinePoint(l: Line, pt: Vec2): boolean {
+export function testLinePoint(l: Line, pt: Vec2): boolean {
 	return false;
 }
 
 // TODO
-function testLineCircle(l: Line, c: Circle): boolean {
+export function testLineCircle(l: Line, c: Circle): boolean {
 	return false;
 }
 
-function testLinePolygon(l: Line, p: Polygon): boolean {
+export function testLinePolygon(l: Line, p: Polygon): boolean {
 
 	// test if line is inside
 	if (testPolygonPoint(p, l.p1) || testPolygonPoint(p, l.p2)) {
@@ -655,20 +695,20 @@ function testLinePolygon(l: Line, p: Polygon): boolean {
 
 }
 
-function testCirclePoint(c: Circle, p: Point): boolean {
+export function testCirclePoint(c: Circle, p: Point): boolean {
 	return c.center.dist(p) < c.radius;
 }
 
-function testCircleCircle(c1: Circle, c2: Circle): boolean {
+export function testCircleCircle(c1: Circle, c2: Circle): boolean {
 	return c1.center.dist(c2.center) < c1.radius + c2.radius;
 }
 
 // TODO
-function testCirclePolygon(c: Circle, p: Polygon): boolean {
+export function testCirclePolygon(c: Circle, p: Polygon): boolean {
 	return false;
 }
 
-function testPolygonPolygon(p1: Polygon, p2: Polygon): boolean {
+export function testPolygonPolygon(p1: Polygon, p2: Polygon): boolean {
 	for (let i = 0; i < p1.length; i++) {
 		const l = {
 			p1: p1[i],
@@ -682,7 +722,7 @@ function testPolygonPolygon(p1: Polygon, p2: Polygon): boolean {
 }
 
 // https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
-function testPolygonPoint(p: Polygon, pt: Point): boolean {
+export function testPolygonPoint(p: Polygon, pt: Point): boolean {
 
 	let c = false;
 
@@ -699,11 +739,11 @@ function testPolygonPoint(p: Polygon, pt: Point): boolean {
 
 }
 
-function testPointPoint(p1: Point, p2: Point): boolean {
+export function testPointPoint(p1: Point, p2: Point): boolean {
 	return p1.eq(p2);
 }
 
-function testAreaRect(a: Area, r: Rect): boolean {
+export function testAreaRect(a: Area, r: Rect): boolean {
 	switch (a.shape) {
 		case "rect": return testRectRect(r, a);
 		case "line": return testRectLine(r, a);
@@ -714,7 +754,7 @@ function testAreaRect(a: Area, r: Rect): boolean {
 	throw new Error(`Unknown area shape: ${(a as Area).shape}`);
 }
 
-function testAreaLine(a: Area, l: Line): boolean {
+export function testAreaLine(a: Area, l: Line): boolean {
 	switch (a.shape) {
 		case "rect": return testRectLine(a, l);
 		case "line": return Boolean(testLineLine(a, l));
@@ -725,7 +765,7 @@ function testAreaLine(a: Area, l: Line): boolean {
 	throw new Error(`Unknown area shape: ${(a as Area).shape}`);
 }
 
-function testAreaCircle(a: Area, c: Circle): boolean {
+export function testAreaCircle(a: Area, c: Circle): boolean {
 	switch (a.shape) {
 		case "rect": return testRectCircle(a, c);
 		case "line": return testLineCircle(a, c);
@@ -736,7 +776,7 @@ function testAreaCircle(a: Area, c: Circle): boolean {
 	throw new Error(`Unknown area shape: ${(a as Area).shape}`);
 }
 
-function testAreaPolygon(a: Area, p: Polygon): boolean {
+export function testAreaPolygon(a: Area, p: Polygon): boolean {
 	switch (a.shape) {
 		case "rect": return testRectPolygon(a, p);
 		case "line": return testLinePolygon(a, p);
@@ -747,7 +787,7 @@ function testAreaPolygon(a: Area, p: Polygon): boolean {
 	throw new Error(`Unknown area shape: ${(a as Area).shape}`);
 }
 
-function testAreaPoint(a: Area, p: Point): boolean {
+export function testAreaPoint(a: Area, p: Point): boolean {
 	switch (a.shape) {
 		case "rect": return testRectPoint(a, p);
 		case "line": return testLinePoint(a, p);
@@ -758,7 +798,7 @@ function testAreaPoint(a: Area, p: Point): boolean {
 	throw new Error(`Unknown area shape: ${(a as Area).shape}`);
 }
 
-function testAreaArea(a1: Area, a2: Area): boolean {
+export function testAreaArea(a1: Area, a2: Area): boolean {
 	switch (a2.shape) {
 		case "rect": return testAreaRect(a1, a2);
 		case "line": return testAreaLine(a1, a2);
@@ -769,7 +809,7 @@ function testAreaArea(a1: Area, a2: Area): boolean {
 	throw new Error(`Unknown area shape: ${(a2 as Area).shape}`);
 }
 
-function minkDiff(r1: Rect, r2: Rect): Rect {
+export function minkDiff(r1: Rect, r2: Rect): Rect {
 	return {
 		p1: vec2(r1.p1.x - r2.p2.x, r1.p1.y - r2.p2.y),
 		p2: vec2(r1.p2.x - r2.p1.x, r1.p2.y - r2.p1.y),
@@ -784,42 +824,3 @@ export class Line {
 		this.p2 = p2;
 	}
 }
-
-export {
-	vec2,
-	quad,
-	rng,
-	rand,
-	randi,
-	randSeed,
-	chance,
-	choose,
-	clamp,
-	lerp,
-	map,
-	mapc,
-	wave,
-	deg2rad,
-	rad2deg,
-	testAreaRect,
-	testAreaLine,
-	testAreaCircle,
-	testAreaPolygon,
-	testAreaPoint,
-	testAreaArea,
-	testLineLineT,
-	testRectRect2,
-	testLineLine,
-	testRectRect,
-	testRectLine,
-	testRectPoint,
-	testPolygonPoint,
-	testLinePolygon,
-	testPolygonPolygon,
-	testCircleCircle,
-	testCirclePoint,
-	testRectPolygon,
-	minkDiff,
-	vec2FromAngle,
-	isVec2,
-};

--- a/src/math.ts
+++ b/src/math.ts
@@ -65,6 +65,10 @@ export class Vec2 {
 		this.x = x;
 		this.y = y;
 	}
+	static LEFT = new Vec2(-1, 0);
+	static RIGHT = new Vec2(1, 0);
+	static UP = new Vec2(0, -1);
+	static DOWN = new Vec2(0, 1);
 	clone(): Vec2 {
 		return new Vec2(this.x, this.y);
 	}
@@ -121,23 +125,14 @@ export class Vec2 {
 }
 
 export function vec2(...args): Vec2 {
-
-	if (args.length === 0) {
-		return vec2(0, 0);
-	}
-
 	if (args.length === 1) {
-		if (typeof args[0] === "number") {
-			return vec2(args[0], args[0]);
-		} else if (args[0] instanceof Vec2) {
+		if (args[0] instanceof Vec2) {
 			return vec2(args[0].x, args[0].y);
 		} else if (Array.isArray(args[0]) && args[0].length === 2) {
 			return vec2.apply(null, args[0]);
 		}
 	}
-
 	return new Vec2(...args);
-
 }
 
 // TODO: Vec2.fromAngle
@@ -174,13 +169,18 @@ export class Color {
 		this.b = clamp(b, 0, 255);
 	}
 
-	static white() {
-		return new Color(255, 255, 255);
-	}
-
 	static fromArray(arr: number[]) {
 		return new Color(arr[0], arr[1], arr[2])
 	}
+
+	static RED = rgb(255, 0, 0);
+	static GREEN = rgb(0, 255, 0);
+	static BLUE = rgb(0, 0, 255);
+	static YELLOW = rgb(255, 255, 0);
+	static MAGENTA = rgb(255, 0, 255);
+	static CYAN = rgb(0, 255, 255);
+	static WHITE = rgb(255, 255, 255);
+	static BLACK = rgb(0, 0, 0);
 
 	clone(): Color {
 		return new Color(this.r, this.g, this.b);
@@ -243,7 +243,7 @@ export class Color {
 		const g = hue2rgb(p, q, h);
 		const b = hue2rgb(p, q, h - 1 / 3);
 
-		return rgb(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255));
+		return new Color(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255));
 
 	}
 
@@ -258,10 +258,9 @@ export function rgb(...args): Color {
 		} else if (Array.isArray(args[0]) && args[0].length === 3) {
 			return Color.fromArray(args[0]);
 		}
-	} else if (args.length === 3) {
-		return new Color(args[0], args[1], args[2]);
 	}
-	throw new Error(`Invalid args to rgb(): ${[...args]}`);
+	// @ts-ignore
+	return new Color(...args);
 }
 
 export const hsl2rgb = (h, s, l) => Color.fromHSL(h, s, l);
@@ -271,14 +270,11 @@ export class Quad {
 	y: number = 0;
 	w: number = 1;
 	h: number = 1;
-	constructor(x, y, w, h) {
+	constructor(x: number = 0, y: number = 0, w: number = 1, h: number = 1) {
 		this.x = x;
 		this.y = y;
 		this.w = w;
 		this.h = h;
-	}
-	static full() {
-		return new Quad(0, 0, 1, 1);
 	}
 	scale(other: Quad): Quad {
 		return new Quad(

--- a/src/math.ts
+++ b/src/math.ts
@@ -63,6 +63,10 @@ export class Vec2 {
 		this.x = x;
 		this.y = y;
 	}
+	static fromAngle(deg: number) {
+		const angle = deg2rad(deg);
+		return new Vec2(Math.cos(angle), Math.sin(angle));
+	}
 	static LEFT = new Vec2(-1, 0);
 	static RIGHT = new Vec2(1, 0);
 	static UP = new Vec2(0, -1);
@@ -131,12 +135,6 @@ export function vec2(...args): Vec2 {
 		}
 	}
 	return new Vec2(...args);
-}
-
-// TODO: Vec2.fromAngle
-export function vec2FromAngle(deg: number): Vec2 {
-	const angle = deg2rad(deg);
-	return vec2(Math.cos(angle), Math.sin(angle));
 }
 
 export class Vec3 {

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,0 +1,30 @@
+export default class Timer {
+
+	time: number
+	action: () => void
+	finished: boolean = false
+	paused: boolean = false
+
+	constructor(time: number, action: () => void) {
+		this.time = time;
+		this.action = action;
+	}
+
+	tick(dt: number): boolean {
+		if (this.finished || this.paused) return false;
+		this.time -= dt;
+		if (this.time <= 0) {
+			this.action();
+			this.finished = true;
+			this.time = 0;
+			return true;
+		}
+		return false;
+	}
+
+	reset(time) {
+		this.time = time;
+		this.finished = false;
+	}
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3035,6 +3035,10 @@ export declare class Vec2 {
 	static RIGHT: Vec2
 	static UP: Vec2
 	static DOWN: Vec2
+	static fromAngle(deg: number): Vec2
+	constructor(x: number, y: number)
+	constructor(xy: number)
+	constructor()
 	clone(): Vec2
 	/**
 	 * Returns the addition with another vector.

--- a/src/types.ts
+++ b/src/types.ts
@@ -3028,61 +3028,65 @@ export type Origin =
 	| "botright"
 	;
 
-export interface Vec2 {
-	x: number,
-	y: number,
-	clone(): Vec2,
+export declare class Vec2 {
+	x: number
+	y: number
+	static LEFT: Vec2
+	static RIGHT: Vec2
+	static UP: Vec2
+	static DOWN: Vec2
+	clone(): Vec2
 	/**
 	 * Returns the addition with another vector.
 	 */
-	add(p: Vec2): Vec2,
-	add(x: number, y: number): Vec2,
+	add(p: Vec2): Vec2
+	add(x: number, y: number): Vec2
 	/**
 	 * Returns the subtraction with another vector.
 	 */
-	sub(p: Vec2): Vec2,
-	sub(x: number, y: number): Vec2,
+	sub(p: Vec2): Vec2
+	sub(x: number, y: number): Vec2
 	/**
 	 * Scale by another vector, or a single number.
 	 */
-	scale(p: Vec2): Vec2,
-	scale(s: number): Vec2,
-	scale(sx: number, sy: number): Vec2,
+	scale(p: Vec2): Vec2
+	scale(s: number): Vec2
+	scale(sx: number, sy: number): Vec2
 	/**
 	 * Get the dot product with another vector.
 	 */
-	dot(p: Vec2): number,
+	dot(p: Vec2): number
 	/**
 	 * Get distance between another vector.
 	 */
-	dist(p: Vec2): number,
-	len(): number,
+	dist(p: Vec2): number
+	len(): number
 	/**
 	 * Get the unit vector (length of 1).
 	 */
-	unit(): Vec2,
+	unit(): Vec2
 	/**
 	 * Get the perpendicular vector.
 	 */
-	normal(): Vec2,
+	normal(): Vec2
 	/**
 	 * Get the angle between another vector
 	 */
-	angle(p: Vec2): number,
+	angle(p: Vec2): number
 	/**
 	 * Linear interpolate to a destination vector
 	 */
-	lerp(p: Vec2, t: number): Vec2,
+	lerp(p: Vec2, t: number): Vec2
 	/**
 	 * To n precision floating point.
 	 */
-	toFixed(n: number): Vec2,
-	eq(p: Vec2): boolean,
-	toString(): string,
+	toFixed(n: number): Vec2
+	eq(p: Vec2): boolean
+	toString(): string
 	/**
 	 * @deprecated v2000.2 Use toString() instead.
 	 */
-	str(): string,
+	str(): string
 }
 
 export interface Vec3 {
@@ -3138,8 +3142,15 @@ export declare class Color {
 	 */
 	b: number;
 	constructor(r: number, g: number, b: number);
-	static white(): Color;
 	static fromArray(arr: number[]): Color;
+	static RED: Color;
+	static GREEN: Color;
+	static BLUE: Color;
+	static YELLOW: Color;
+	static MAGENTA: Color;
+	static CYAN: Color;
+	static WHITE: Color;
+	static BLACK: Color;
 	clone(): Color;
 	/**
 	 * Lighten the color (adds RGB by n).

--- a/src/types.ts
+++ b/src/types.ts
@@ -3107,50 +3107,61 @@ export interface Vec4 {
 	w: number,
 }
 
-export interface Mat4 {
-	m: number[],
-	clone(): Mat4,
-	mult(m: Mat4): Mat4,
-	multVec4(m: Vec4): Vec4,
-	multVec3(m: Vec3): Vec3,
-	multVec2(m: Vec2): Vec2,
-	scale(s: Vec2): Mat4,
-	translate(p: Vec2): Mat4,
-	rotateX(a: number): Mat4,
-	rotateY(a: number): Mat4,
-	rotateZ(a: number): Mat4,
-	invert(): Mat4,
+export declare class Mat4 {
+	m: number[];
+	constructor(m?: number[]);
+	clone(): Mat4;
+	mult(other: Mat4): Mat4;
+	multVec4(p: Vec4): Vec4;
+	multVec3(p: Vec3): Vec3;
+	multVec2(p: Vec2): Vec2;
+	static translate(p: Vec2): Mat4;
+	static scale(s: Vec2): Mat4;
+	static rotateX(a: number): Mat4;
+	static rotateY(a: number): Mat4;
+	static rotateZ(a: number): Mat4;
+	translate(p: Vec2): Mat4;
+	scale(s: Vec2): Mat4;
+	rotateX(a: number): Mat4;
+	rotateY(a: number): Mat4;
+	rotateZ(a: number): Mat4;
+	invert(): Mat4;
+	toString(): string;
 }
 
 /**
  * 0-255 RGBA color.
  */
-export interface Color {
+export declare class Color {
 	/**
 	 * Red (0-255).
 	 */
-	r: number,
+	r: number;
 	/**
 	 * Green (0-255).
 	 */
-	g: number,
+	g: number;
 	/**
 	 * Blue (0-255).
 	 */
-	b: number,
-	clone(): Color,
+	b: number;
+	constructor(r: number, g: number, b: number);
+	static white(): Color;
+	static fromArray(arr: number[]): Color;
+	clone(): Color;
 	/**
 	 * Lighten the color (adds RGB by n).
 	 */
-	lighten(n: number): Color,
+	lighten(n: number): Color;
 	/**
 	 * Darkens the color (subtracts RGB by n).
 	 */
-	darken(n: number): Color,
-	invert(): Color,
-	mult(other: Color): Color,
-	eq(c: Color): boolean,
-	str(): string,
+	darken(n: number): Color;
+	invert(): Color;
+	mult(other: Color): Color;
+	eq(c: Color): boolean;
+	str(): string;
+	toString(): string;
 }
 
 export interface Quad {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1651,19 +1651,7 @@ export interface KaboomCtx {
 		h2: number,
 	): number,
 	/**
-	 * Get directional vector from an angle.
-	 *
-	 * @example
-	 * ```js
-	 * // move toward bottom right in 45 degrees
-	 * player.onUpdate(() => {
-	 *     player.move(vec2FromAngle(45).scale(SPEED))
-	 * })
-	 * ```
-	 */
-	vec2FromAngle(deg: number): Vec2,
-	/**
-	 * @deprecated v2000.2 Use vec2FromAngle instead.
+	 * @deprecated v2000.2 Use Vec2.fromAngle instead.
 	 */
 	dir(deg: number): Vec2,
 	/**
@@ -3090,6 +3078,10 @@ export interface Vec2 {
 	 */
 	toFixed(n: number): Vec2,
 	eq(p: Vec2): boolean,
+	toString(): string,
+	/**
+	 * @deprecated v2000.2 Use toString() instead.
+	 */
 	str(): string,
 }
 
@@ -3110,16 +3102,16 @@ export interface Vec4 {
 export declare class Mat4 {
 	m: number[];
 	constructor(m?: number[]);
-	clone(): Mat4;
-	mult(other: Mat4): Mat4;
-	multVec4(p: Vec4): Vec4;
-	multVec3(p: Vec3): Vec3;
-	multVec2(p: Vec2): Vec2;
 	static translate(p: Vec2): Mat4;
 	static scale(s: Vec2): Mat4;
 	static rotateX(a: number): Mat4;
 	static rotateY(a: number): Mat4;
 	static rotateZ(a: number): Mat4;
+	clone(): Mat4;
+	mult(other: Mat4): Mat4;
+	multVec4(p: Vec4): Vec4;
+	multVec3(p: Vec3): Vec3;
+	multVec2(p: Vec2): Vec2;
 	translate(p: Vec2): Mat4;
 	scale(s: Vec2): Mat4;
 	rotateX(a: number): Mat4;
@@ -3160,8 +3152,11 @@ export declare class Color {
 	invert(): Color;
 	mult(other: Color): Color;
 	eq(c: Color): boolean;
-	str(): string;
 	toString(): string;
+	/**
+	 * @deprecated v2000.2 Use toString() instead.
+	 */
+	str(): string;
 }
 
 export interface Quad {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3089,18 +3089,19 @@ export declare class Vec2 {
 	str(): string
 }
 
-export interface Vec3 {
-	x: number,
-	y: number,
-	z: number,
-	xy(): Vec2,
+export declare class Vec3 {
+	x: number
+	y: number
+	z: number
+	constructor(x: number, y: number, z: number)
+	xy(): Vec2
 }
 
-export interface Vec4 {
-	x: number,
-	y: number,
-	z: number,
-	w: number,
+export declare class Vec4 {
+	x: number
+	y: number
+	z: number
+	w: number
 }
 
 export declare class Mat4 {
@@ -3170,14 +3171,15 @@ export declare class Color {
 	str(): string;
 }
 
-export interface Quad {
-	x: number,
-	y: number,
-	w: number,
-	h: number,
-	scale(q: Quad): Quad,
-	clone(): Quad,
-	eq(q: Quad): boolean,
+export declare class Quad {
+	x: number
+	y: number
+	w: number
+	h: number
+	constructor(x: number, y: number, w: number, h: number)
+	scale(q: Quad): Quad
+	clone(): Quad
+	eq(q: Quad): boolean
 }
 
 export type RNGValue =
@@ -3193,19 +3195,22 @@ export interface RNG {
 	gen<T extends RNGValue>(a: T, b: T): T,
 }
 
-export interface Rect {
-	p1: Vec2,
-	p2: Vec2,
+export declare class Rect {
+	p1: Vec2
+	p2: Vec2
+	constructor(p1: Vec2, p2: Vec2)
 }
 
-export interface Line {
-	p1: Vec2,
-	p2: Vec2,
+export declare class Line {
+	p1: Vec2
+	p2: Vec2
+	constructor(p1: Vec2, p2: Vec2)
 }
 
-export interface Circle {
-	center: Vec2,
-	radius: number,
+export declare class Circle {
+	center: Vec2
+	radius: number
+	constructor(pos: Vec2, radius: number)
 }
 
 export type Polygon = Vec2[];
@@ -3897,15 +3902,20 @@ export interface BodyCompOpt {
 	solid?: boolean,
 }
 
-export interface Timer {
+export declare class Timer {
 	/**
-	 * Timer left.
+	 * Time left.
 	 */
-	time: number,
+	time: number
 	/**
-	 * The action to take after time is up.
+	 * The action to take when timer is up
 	 */
-	action(): void,
+	action: () => void
+	readonly finished: boolean
+	paused: boolean
+	constructor(time: number, action: () => void)
+	tick(dt: number): boolean
+	reset(time: number): void
 }
 
 export interface TimerComp extends Comp {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,8 +67,14 @@ export const uid = (() => {
 	return () => id++;
 })();
 
-export const deprecateMsg = (oldName: string, newName: string) =>
-	console.warn(`${oldName} is deprecated. Use ${newName} instead.`);
+const warned = new Set();
+
+export function deprecateMsg(oldName: string, newName: string) {
+	if (!warned.has(oldName)) {
+		warned.add(oldName);
+		console.warn(`${oldName} is deprecated. Use ${newName} instead.`);
+	}
+}
 
 export const deprecate = (oldName: string, newName: string, newFunc: (...args) => any) => (...args) => {
 	deprecateMsg(oldName, newName);


### PR DESCRIPTION
For some structures like `Color`, `Vec2`, `Timer`, `Line` it makes more sense to be a `class` instead of factory + closed vars, so it can be `instanceof` and have `static`. 

`class` should also be faster than factory methods, however esbuild seems to add overhead to classes with the current setting, will investigate later.