### PR TITLE
Make esbuild not generate polyfills

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,7 +32,6 @@ fmts.forEach((fmt) => {
 	esbuild.build({
 		bundle: true,
 		sourcemap: true,
-		target: "es6",
 		minify: !dev,
 		keepNames: true,
 		loader: {


### PR DESCRIPTION
The biggest source of kaboom slowness is esbuild generating polyfills for new js features like spread args, disabling it nearly doubles the performance. It's better to just don't use new features if there's breakage.