### PR TITLE
Fix not updating anything when debug is set to false

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -5348,7 +5348,7 @@ run(() => {
 		// TODO: this gives the latest mousePos in input handlers but uses cam matrix from last frame
 		game.trigger("input");
 
-		if (!debug.paused && gopt.debug !== false) {
+		if (!debug.paused) {
 			updateFrame();
 		}
 


### PR DESCRIPTION
There's a logic error that makes the game not updating at all when `kaboom({ debug: false })`, and we actually don't have to check for `gopt.debug` here