### PR TITLE
Replace deprecated dir() with Vec2.fromAngle()

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1450,7 +1450,7 @@ export interface KaboomCtx {
 	 * vec2(100, 80)
 	 *
 	 * // move to 150 degrees direction with by length 10
-	 * player.pos = pos.add(dir(150).scale(10))
+	 * player.pos = pos.add(Vec2.fromAngle(150).scale(10))
 	 * ```
 	 */
 	vec2(x: number, y: number): Vec2,


### PR DESCRIPTION
I noticed it for https://kaboomjs.com/#vec2 and felt it should be up to date.