### PR TITLE
Remove focus()

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4971,10 +4971,6 @@ function record(frameRate?): Recording {
 
 }
 
-function isFocused(): boolean {
-	return document.activeElement === app.canvas;
-}
-
 // aliases for root game obj operations
 function add<T>(comps: CompList<T> | GameObj<T>): GameObj<T> {
 	return game.root.add(comps);
@@ -5552,8 +5548,6 @@ const ctx: KaboomCtx = {
 	time,
 	screenshot,
 	record,
-	isFocused,
-	focus,
 	cursor,
 	regCursor,
 	fullscreen,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4971,6 +4971,10 @@ function record(frameRate?): Recording {
 
 }
 
+function isFocused(): boolean {
+	return document.activeElement === app.canvas;
+}
+
 // aliases for root game obj operations
 function add<T>(comps: CompList<T> | GameObj<T>): GameObj<T> {
 	return game.root.add(comps);
@@ -5548,6 +5552,7 @@ const ctx: KaboomCtx = {
 	time,
 	screenshot,
 	record,
+	isFocused,
 	cursor,
 	regCursor,
 	fullscreen,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1118,16 +1118,6 @@ export interface KaboomCtx {
 	 */
 	time(): number,
 	/**
-	 * If the game canvas is currently focused.
-	 *
-	 * @since v2000.1
-	 */
-	isFocused(): boolean,
-	/**
-	 * Focus on the game canvas.
-	 */
-	focus(): void,
-	/**
 	 * Is currently on a touch screen device.
 	 */
 	isTouch(): boolean,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1118,6 +1118,12 @@ export interface KaboomCtx {
 	 */
 	time(): number,
 	/**
+	 * If the game canvas is currently focused.
+	 *
+	 * @since v2000.1
+	 */
+	isFocused(): boolean,
+	/**
 	 * Is currently on a touch screen device.
 	 */
 	isTouch(): boolean,


### PR DESCRIPTION
`focus()` just calls `canvas.focus()` which is trivial to write, however it conflicts with [`window.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/focus) and messes up typescript