### PR TITLE
Remove layers in favor of parent game obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added `loadProgress()` that returns a `0.0 - 1.0` that indicates current asset loading progress
 - added `kaboom()` option `loadingScreen` where you can turn off the default loading screen
 - added `drawMasked()` and `drawSubtracted()`
+- removed `layers()` in favor of parent game objects (see "layers" demo)
 
 ### v2000.2.6
 

--- a/demo/layer.js
+++ b/demo/layer.js
@@ -2,21 +2,19 @@ kaboom()
 
 loadSprite("bean", "/sprites/bean.png")
 
-// layer "ui" will be on top of layer "game", with "game" layer being the default
-layers([
-	"game",
-	"ui",
-], "game")
+// Create a parent node that won't be affected by camera (fixed) and will be drawn on top (z of 100)
+const ui = add([
+	fixed(),
+	z(100),
+])
 
-add([
+// This will be on top, because the parent node has z(100)
+ui.add([
 	sprite("bean"),
 	scale(5),
-	// specify layer with layer() component
-	layer("ui"),
 	color(0, 0, 255),
 ])
 
-// this obj doesn't have a layer() component, fallback on default "game" layer
 add([
 	sprite("bean"),
 	pos(100, 100),

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,10 +362,6 @@ export interface KaboomCtx {
 	 */
 	origin(o: Origin | Vec2): OriginComp,
 	/**
-	 * Which layer this object belongs to.
-	 */
-	layer(l: string): LayerComp,
-	/**
 	 * Determines the draw order for objects on the same layer. Object will be drawn on top if z value is bigger.
 	 */
 	z(z: number): ZComp,
@@ -1237,32 +1233,6 @@ export interface KaboomCtx {
 	 * Get / set gravity.
 	 */
 	gravity(g: number): number,
-	/**
-	 * Define layers (the last one will be on top).
-	 *
-	 * @example
-	 * ```js
-	 * // defining 3 layers, "ui" will be drawn on top most, with default layer being "game"
-	 * layers([
-	 *     "bg",
-	 *     "game",
-	 *     "ui",
-	 * ], "game")
-	 *
-	 * // use layer() comp to define which layer an obj belongs to
-	 * add([
-	 *     text(score),
-	 *     layer("ui"),
-	 *     fixed(),
-	 * ])
-	 *
-	 * // without layer() comp it'll fall back to default layer, which is "game"
-	 * add([
-	 *     sprite("froggy"),
-	 * ])
-	 * ```
-	 */
-	layers(list: string[], def?: string): void,
 	/**
 	 * Get / set the cursor (css). Cursor will be reset to "default" every frame so use this in an per-frame action.
 	 *
@@ -3269,13 +3239,6 @@ export interface OriginComp extends Comp {
 	 * Origin point for render.
 	 */
 	origin: Origin | Vec2,
-}
-
-export interface LayerComp extends Comp {
-	/**
-	 * Which layer this game obj belongs to.
-	 */
-	layer: string,
 }
 
 export interface ZComp extends Comp {


### PR DESCRIPTION
The functionality of layers can be converged into parent game objects, making it an redundant system.

Old

```js
kaboom()

loadSprite("bean", "/sprites/bean.png")

// layer "ui" will be on top of layer "game", with "game" layer being the default
layers([
	"game",
	"ui",
], "game")

add([
	sprite("bean"),
	scale(5),
	// specify layer with layer() component
	layer("ui"),
	color(0, 0, 255),
])

// this obj doesn't have a layer() component, fallback on default "game" layer
add([
	sprite("bean"),
	pos(100, 100),
	scale(5),
])

```

New

```js
kaboom()

loadSprite("bean", "/sprites/bean.png")

// Create a parent node that won't be affected by camera (fixed) and will be drawn on top (z of 100)
const ui = add([
	fixed(),
	z(100),
])

// This will be on top, because the parent node has z(100)
ui.add([
	sprite("bean"),
	scale(5),
	color(0, 0, 255),
])

add([
	sprite("bean"),
	pos(100, 100),
	scale(5),
])
```