### PR TITLE
Support pixel density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added `drawMasked()` and `drawSubtracted()`
 - removed `layers()` in favor of parent game objects (see "layers" demo)
 - added `pushRotateX()`, `pushRotateY()` and `pushRotateZ()`
+- added `pixelDensity` option to `kaboom()`
 
 ### v2000.2.6
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -441,8 +441,17 @@ const app = (() => {
 		canvas.height = canvas.parentElement.offsetHeight;
 	}
 
+	const cw = canvas.width;
+	const ch = canvas.height;
+	const pixelDensity = gopt.pixelDensity || window.devicePixelRatio;
+
+	canvas.width *= pixelDensity;
+	canvas.height *= pixelDensity;
+
 	// canvas css styles
 	const styles = [
+		`width: ${cw}px`,
+		`height: ${ch}px`,
 		"outline: none",
 		"cursor: default",
 	];
@@ -463,6 +472,7 @@ const app = (() => {
 
 		canvas: canvas,
 		scale: gscale,
+		pixelDensity: pixelDensity,
 
 		// keep track of all button states
 		keyStates: {} as Record<Key, ButtonState>,
@@ -603,8 +613,8 @@ const gfx = (() => {
 		viewport: {
 			x: 0,
 			y: 0,
-			width: gl.drawingBufferWidth,
-			height: gl.drawingBufferHeight,
+			width: gl.drawingBufferWidth / app.pixelDensity,
+			height: gl.drawingBufferHeight / app.pixelDensity,
 		},
 
 	};
@@ -2392,8 +2402,9 @@ function drawFormattedText(ftext: FormattedText) {
 function updateViewport() {
 
 	// canvas size
-	const cw = gl.drawingBufferWidth;
-	const ch = gl.drawingBufferHeight;
+	const cw = gl.drawingBufferWidth / app.pixelDensity;
+	const ch = gl.drawingBufferHeight / app.pixelDensity;
+	const pd = app.pixelDensity;
 
 	// game size
 	const gw = width();
@@ -2442,8 +2453,8 @@ function updateViewport() {
 			const sw = ch * rg;
 			const sh = ch;
 			const x = (cw - sw) / 2;
-			gl.scissor(x, 0, sw, sh);
-			gl.viewport(x, 0, sw, ch);
+			gl.scissor(x * pd, 0, sw * pd, sh * pd);
+			gl.viewport(x * pd, 0, sw * pd, ch * pd);
 			gfx.viewport = {
 				x: x,
 				y: 0,
@@ -2458,8 +2469,8 @@ function updateViewport() {
 			const sw = cw;
 			const sh = cw / rg;
 			const y = (ch - sh) / 2;
-			gl.scissor(0, y, sw, sh);
-			gl.viewport(0, y, cw, sh);
+			gl.scissor(0, y * pd, sw * pd, sh * pd);
+			gl.viewport(0, y * pd, cw * pd, sh * pd);
 			gfx.viewport = {
 				x: 0,
 				y: y,
@@ -2478,7 +2489,7 @@ function updateViewport() {
 			throw new Error("Stretching requires width and height defined.");
 		}
 
-		gl.viewport(0, 0, cw, ch);
+		gl.viewport(0, 0, cw * 2, ch * pd);
 
 		gfx.viewport = {
 			x: 0,
@@ -2492,7 +2503,7 @@ function updateViewport() {
 
 	gfx.width = cw / app.scale;
 	gfx.height = ch / app.scale;
-	gl.viewport(0, 0, cw, ch);
+	gl.viewport(0, 0, cw * pd, ch * pd);
 
 	gfx.viewport = {
 		x: 0,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -613,8 +613,8 @@ const gfx = (() => {
 		viewport: {
 			x: 0,
 			y: 0,
-			width: gl.drawingBufferWidth / app.pixelDensity,
-			height: gl.drawingBufferHeight / app.pixelDensity,
+			width: gl.drawingBufferWidth,
+			height: gl.drawingBufferHeight,
 		},
 
 	};
@@ -2402,9 +2402,9 @@ function drawFormattedText(ftext: FormattedText) {
 function updateViewport() {
 
 	// canvas size
-	const cw = gl.drawingBufferWidth / app.pixelDensity;
-	const ch = gl.drawingBufferHeight / app.pixelDensity;
 	const pd = app.pixelDensity;
+	const cw = gl.drawingBufferWidth / pd;
+	const ch = gl.drawingBufferHeight / pd;
 
 	// game size
 	const gw = width();

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2489,7 +2489,7 @@ function updateViewport() {
 			throw new Error("Stretching requires width and height defined.");
 		}
 
-		gl.viewport(0, 0, cw * 2, ch * pd);
+		gl.viewport(0, 0, cw * pd, ch * pd);
 
 		gfx.viewport = {
 			x: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2029,7 +2029,7 @@ export interface KaboomOpt {
 	 */
 	font?: string,
 	/**
-	 * Device pixel scale (defaults to window.devicePixelRatio).
+	 * Device pixel scale (defaults to window.devicePixelRatio, high pixel density will hurt performance).
 	 *
 	 * @since v2001.0
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2029,6 +2029,12 @@ export interface KaboomOpt {
 	 */
 	font?: string,
 	/**
+	 * Device pixel scale (defaults to window.devicePixelRatio).
+	 *
+	 * @since v2001.0
+	 */
+	pixelDensity?: number,
+	/**
 	 * Disable antialias and enable sharp pixel display.
 	 */
 	crisp?: boolean,


### PR DESCRIPTION
Kaboom didn't properly handle device pixel density, leading to blurry rendering. This PR properly handle device pixel density, also exposes an option like
```js
kaboom({
    pixelDensity: 4,
})
```
to further configure the pixel density (similar to p5's [`pixelDensity()`](https://p5js.org/reference/#/p5/pixelDensity))

Before:
<img width="403" alt="1644265126" src="https://user-images.githubusercontent.com/9929523/152865087-0c4a5220-788f-4424-a8e2-04e883088bfa.png">

After:
<img width="350" alt="1644265164" src="https://user-images.githubusercontent.com/9929523/152865151-086f07ac-d8b8-410e-afc8-d4ef51186673.png">

When `pixeldensity: 4`
<img width="309" alt="1644265117" src="https://user-images.githubusercontent.com/9929523/152865092-b39f8023-bb97-4942-87d7-872b2bc529a5.png">
