### PR TITLE
Add Asset wrapper type

### DIFF
--- a/demo/loader.js
+++ b/demo/loader.js
@@ -8,9 +8,9 @@ kaboom({
 let spr = null
 
 // Every loadXXX() function returns a Promise<Data>. You can customize the error handling, or deal with the raw asset data yourself instead of using a name.
-loadSprite("bean", "/sprites/bean.png").catch((err) => {
+loadSprite("bean", "/sprites/bean.png").onError((err) => {
 	alert("oh no we failed to load bean")
-}).then((data) => {
+}).onLoad((data) => {
 	// The promise resolves to the raw sprite data
 	spr = data
 })
@@ -58,7 +58,7 @@ onDraw(() => {
 	if (spr) {
 		drawSprite({
 			// You can pass raw sprite data here instead of the name
-			sprite: spr
+			sprite: spr,
 		})
 	}
 

--- a/demo/loader.js
+++ b/demo/loader.js
@@ -7,7 +7,7 @@ kaboom({
 
 let spr = null
 
-// Every loadXXX() function returns a Promise<Data>. You can customize the error handling, or deal with the raw asset data yourself instead of using a name.
+// Every loadXXX() function returns a Asset<Data> where you can customize the error handling (by default it'll stop the game and log on screen), or deal with the raw asset data yourself instead of using a name.
 loadSprite("bean", "/sprites/bean.png").onError((err) => {
 	alert("oh no we failed to load bean")
 }).onLoad((data) => {

--- a/demo/spriteatlas.js
+++ b/demo/spriteatlas.js
@@ -133,6 +133,9 @@ loadSpriteAtlas("/sprites/dungeon.png", {
 	},
 })
 
+// Can also load from external JSON url
+// loadSpriteAtlas("/sprites/dungeon.png", "/sprites/dungeon.json")
+
 // floor
 addLevel([
 	"xxxxxxxxxx",

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -723,6 +723,9 @@ class Asset<D> {
 		this.loader.finally(action)
 		return this
 	}
+	then(action: (data: D) => void): Asset<D> {
+		return this.onLoad(action)
+	}
 }
 
 class AssetBucket<D> {
@@ -971,7 +974,7 @@ function loadPedit(name: string | null, src: string | PeditFile): Asset<SpriteDa
 			anims: data.anims,
 		});
 
-		resolve(spr.data);
+		resolve(spr);
 
 	}));
 
@@ -983,7 +986,7 @@ function loadAseprite(
 	jsonSrc: string
 ): Asset<SpriteData> {
 	return assets.sprites.add(name, new Promise(async (resolve, reject) => {
-		const spr = await loadSprite(null, imgSrc).loader;
+		const spr = await loadSprite(null, imgSrc);
 		const data = typeof jsonSrc === "string" ? await fetchJSON(jsonSrc) : jsonSrc;
 		const size = data.meta.size;
 		spr.frames = data.frames.map((f: any) => {
@@ -1149,7 +1152,12 @@ function resolveFont(
 	src: string | FontData | Asset<FontData> | undefined
 ): FontData | Asset<FontData> | void {
 	if (!src) {
-		return getFont(gopt.font ?? DEF_FONT);
+		const font = getFont(gopt.font ?? DEF_FONT);
+		if (font) {
+			return font.loaded ? font.data : font;
+		} else {
+			return null;
+		}
 	}
 	if (typeof src === "string") {
 		const font = getFont(src)

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -714,6 +714,7 @@ class Asset<D> {
 	error: Error | null = null
 	private onLoadEvents: Event = new Event();
 	private onErrorEvents: Event = new Event();
+	private onFinishEvents: Event = new Event();
 	constructor(loader: Promise<D>) {
 		loader.then((data) => {
 			this.data = data
@@ -726,6 +727,7 @@ class Asset<D> {
 				throw err
 			}
 		}).finally(() => {
+			this.onFinishEvents.trigger()
 			this.done = true
 		})
 	}
@@ -741,6 +743,10 @@ class Asset<D> {
 	}
 	onError(action: (err: Error) => void): Asset<D> {
 		this.onErrorEvents.add(action)
+		return this
+	}
+	onFinish(action: () => void): Asset<D> {
+		this.onFinishEvents.add(action)
 		return this
 	}
 	then(action: (data: D) => void): Asset<D> {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -739,6 +739,9 @@ class Asset<D> {
 	then(action: (data: D) => void): Asset<D> {
 		return this.onLoad(action)
 	}
+	catch(action: (err: Error) => void): Asset<D> {
+		return this.onError(action)
+	}
 }
 
 class AssetBucket<D> {
@@ -4170,14 +4173,23 @@ function sprite(
 				this.stop();
 			}
 
-			curAnim = {
-				name: name,
-				timer: 0,
-				loop: opt.loop ?? anim.loop ?? false,
-				pingpong: opt.pingpong ?? anim.pingpong ?? false,
-				speed: opt.speed ?? anim.speed ?? 10,
-				onEnd: opt.onEnd ?? (() => {}),
-			};
+			curAnim = typeof anim === "number"
+				? {
+					name: name,
+					timer: 0,
+					loop: false,
+					pingpong: false,
+					speed: 0,
+					onEnd: () => {},
+				}
+				: {
+					name: name,
+					timer: 0,
+					loop: opt.loop ?? anim.loop ?? false,
+					pingpong: opt.pingpong ?? anim.pingpong ?? false,
+					speed: opt.speed ?? anim.speed ?? 10,
+					onEnd: opt.onEnd ?? (() => {}),
+				};
 
 			this.frame = typeof anim === "number"
 				? anim

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -700,40 +700,55 @@ const audio = (() => {
 
 })();
 
+class Asset<D> {
+	loader: Promise<D>
+	loaded: boolean = false
+	data: D | null = null
+	constructor(loader: Promise<D>) {
+		this.loader = loader
+		this.onLoad((data) => {
+			this.loaded = true
+			this.data = data
+		})
+	}
+	onLoad(action: (data: D) => void): Asset<D> {
+		this.loader.then(action)
+		return this
+	}
+	onError(action: (err: Error) => void): Asset<D> {
+		this.loader.catch(action)
+		return this
+	}
+	onEnd(action: () => void): Asset<D> {
+		this.loader.finally(action)
+		return this
+	}
+}
+
 class AssetBucket<D> {
-	loading: Map<string | Promise<D>, Promise<D>> = new Map();
-	loaded: Map<string | Promise<D>, D> = new Map();
+	assets: Map<string, Asset<D>> = new Map()
 	lastUID: number = 0;
-	add(name: string | null, loader: Promise<D>): Promise<D> {
+	add(name: string | null, loader: Promise<D>): Asset<D> {
 		// if user don't provide a name we use a generated one
 		const id = name ?? (this.lastUID++ + "");
-		this.loading.set(id, loader);
-		// we also use the Promise returned as a key to allow query assets from the handles returned by loadXXX()
-		const handle = loader.then((data: D) => {
-			this.loaded.set(id, data);
-			this.loaded.set(handle, data);
-			return data;
-		}).finally(() => {
-			this.loading.delete(id);
-			this.loading.delete(handle);
-		});
-		this.loading.set(handle, loader);
-		return handle;
+		const asset = new Asset(loader);
+		this.assets.set(id, asset);
+		return asset;
 	}
-	get(handle: string | Promise<D>): D | Promise<D> | null {
-		return this.getLoaded(handle) ?? this.getLoading(handle);
-	}
-	getLoaded(handle: string | Promise<D>): D | null {
-		return this.loaded.get(handle) ?? null;
-	}
-	getLoading(handle: string | Promise<D>): Promise<D> | null {
-		return this.loading.get(handle) ?? null;
+	get(handle: string): Asset<D> | void {
+		return this.assets.get(handle);
 	}
 	progress(): number {
-		if (this.loaded.size === this.loading.size) {
+		if (this.assets.size === 0) {
 			return 1;
 		}
-		return this.loaded.size / (this.loaded.size + this.loading.size);
+		let loaded = 0;
+		this.assets.forEach((asset) => {
+			if (asset.loaded) {
+				loaded++;
+			}
+		})
+		return loaded / this.assets.size;
 	}
 }
 
@@ -781,7 +796,7 @@ const game = {
 }
 
 // wrap individual loaders with global loader counter, for stuff like progress bar
-function load<T>(prom: Promise<T>): Promise<T> {
+function load<T>(prom: Promise<T>): Asset<T> {
 	return assets.custom.add(null, prom);
 }
 
@@ -847,7 +862,7 @@ function loadFont(
 	gw: number,
 	gh: number,
 	opt: FontLoadOpt = {},
-): Promise<FontData> {
+): Asset<FontData> {
 	return assets.fonts.add(name, loadImg(src)
 		.then((img) => {
 			return makeFont(
@@ -881,38 +896,39 @@ function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1): Quad[] {
 function loadSpriteAtlas(
 	src: SpriteLoadSrc,
 	data: SpriteAtlasData | string
-): Promise<Record<string, SpriteData>> {
-	if (typeof data === "string") {
-		return load(fetchJSON(data)
-			.then((data2) => loadSpriteAtlas(src, data2)));
-	}
-	return load(new Promise(async (resolve, reject) => {
-		const map = {};
-		const loader = loadSprite(null, src);
-		const tasks = Object.keys(data).map((name) => {
-			return assets.sprites.add(name, loader.then((atlas) => {
-				const w = atlas.tex.width;
-				const h = atlas.tex.height;
-				const info = data[name];
-				const spr = new SpriteData(
-					atlas.tex,
-					slice(
-						info.sliceX,
-						info.sliceY,
-						info.x / w,
-						info.y / h,
-						info.width / w,
-						info.height / h
-					),
-					info.anims,
-				);
-				map[name] = spr;
-				return spr;
-			}));
-		});
-		await Promise.all(tasks);
-		resolve(map);
-	}));
+) {
+// ): Asset<Record<string, SpriteData>> {
+// 	if (typeof data === "string") {
+// 		return load(fetchJSON(data)
+// 			.then((data2) => loadSpriteAtlas(src, data2)));
+// 	}
+// 	return load(new Promise(async (resolve, reject) => {
+// 		const map = {};
+// 		const loader = loadSprite(null, src);
+// 		const tasks = Object.keys(data).map((name) => {
+// 			return assets.sprites.add(name, loader.then((atlas) => {
+// 				const w = atlas.tex.width;
+// 				const h = atlas.tex.height;
+// 				const info = data[name];
+// 				const spr = new SpriteData(
+// 					atlas.tex,
+// 					slice(
+// 						info.sliceX,
+// 						info.sliceY,
+// 						info.x / w,
+// 						info.y / h,
+// 						info.width / w,
+// 						info.height / h
+// 					),
+// 					info.anims,
+// 				);
+// 				map[name] = spr;
+// 				return spr;
+// 			}));
+// 		});
+// 		await Promise.all(tasks);
+// 		resolve(map);
+// 	}));
 }
 
 // load a sprite to asset manager
@@ -924,7 +940,7 @@ function loadSprite(
 		sliceY: 1,
 		anims: {},
 	},
-): Promise<SpriteData> {
+): Asset<SpriteData> {
 	return assets.sprites.add(
 		name,
 		typeof src === "string"
@@ -934,7 +950,7 @@ function loadSprite(
 	);
 }
 
-function loadPedit(name: string | null, src: string | PeditFile): Promise<SpriteData> {
+function loadPedit(name: string | null, src: string | PeditFile): Asset<SpriteData> {
 
 	return assets.sprites.add(name, new Promise(async (resolve) => {
 
@@ -955,7 +971,7 @@ function loadPedit(name: string | null, src: string | PeditFile): Promise<Sprite
 			anims: data.anims,
 		});
 
-		resolve(spr);
+		resolve(spr.data);
 
 	}));
 
@@ -965,9 +981,9 @@ function loadAseprite(
 	name: string | null,
 	imgSrc: SpriteLoadSrc,
 	jsonSrc: string
-): Promise<SpriteData> {
+): Asset<SpriteData> {
 	return assets.sprites.add(name, new Promise(async (resolve, reject) => {
-		const spr = await loadSprite(null, imgSrc);
+		const spr = await loadSprite(null, imgSrc).loader;
 		const data = typeof jsonSrc === "string" ? await fetchJSON(jsonSrc) : jsonSrc;
 		const size = data.meta.size;
 		spr.frames = data.frames.map((f: any) => {
@@ -1000,7 +1016,7 @@ function loadShader(
 	vert?: string,
 	frag?: string,
 	isUrl: boolean = false,
-): Promise<ShaderData> {
+): Asset<ShaderData> {
 
 	return assets.shaders.add(name, new Promise<ShaderData>((resolve, reject) => {
 
@@ -1031,7 +1047,7 @@ function loadShader(
 function loadSound(
 	name: string | null,
 	src: string | ArrayBuffer,
-): Promise<SoundData> {
+): Asset<SoundData> {
 	return assets.sounds.add(
 		name,
 		typeof src === "string"
@@ -1040,34 +1056,34 @@ function loadSound(
 	);
 }
 
-function loadBean(name: string = "bean"): Promise<SpriteData> {
+function loadBean(name: string = "bean"): Asset<SpriteData> {
 	return loadSprite(name, beanSrc);
 }
 
-function getSprite(handle: string | Promise<SpriteData>): SpriteData | Promise<SpriteData> | null {
+function getSprite(handle: string): Asset<SpriteData> | void {
 	return assets.sprites.get(handle);
 }
 
-function getSound(handle: string | Promise<SoundData>): SoundData | Promise<SoundData> | null {
-	return assets.sounds.get(handle) ?? null;
+function getSound(handle: string): Asset<SoundData> | void {
+	return assets.sounds.get(handle);
 }
 
-function getFont(handle: string | Promise<FontData>): FontData | Promise<FontData> | null {
+function getFont(handle: string): Asset<FontData> | void {
 	return assets.fonts.get(handle);
 }
 
-function getShader(handle: string | Promise<ShaderData>): ShaderData | Promise<ShaderData> | null {
-	return assets.shaders.get(handle) ?? null;
+function getShader(handle: string): Asset<ShaderData> | void {
+	return assets.shaders.get(handle);
 }
 
 function resolveSprite(
-	src: string | SpriteData | Promise<SpriteData>
-): SpriteData | Promise<SpriteData> | null {
-	if (typeof src === "string" || src instanceof Promise) {
+	src: string | SpriteData | Asset<SpriteData>
+): SpriteData | Asset<SpriteData> | null {
+	if (typeof src === "string") {
 		const spr = getSprite(src)
 		if (spr) {
 			// if it's already loaded or being loading, return it
-			return spr;
+			return spr.loaded ? spr.data : spr;
 		} else if (loadProgress() < 1) {
 			// if there's any other ongoing loading task we return empty and don't error yet
 			return null;
@@ -1077,63 +1093,75 @@ function resolveSprite(
 		}
 	} else if (src instanceof SpriteData) {
 		return src;
+	} else if (src instanceof Asset) {
+		if (src.loaded) {
+			return src.data;
+		}
 	} else {
 		throw new Error(`Invalid sprite: ${src}`);
 	}
 }
 
 function resolveSound(
-	src: string | SoundData | Promise<SoundData>
-): SoundData | Promise<SoundData> | null {
-	if (typeof src === "string" || src instanceof Promise) {
+	src: string | SoundData | Asset<SoundData>
+): SoundData | Asset<SoundData> | null {
+	if (typeof src === "string") {
 		const snd = getSound(src)
 		if (snd) {
-			return snd;
+			return snd.loaded ? snd.data : snd;
 		} else if (loadProgress() < 1) {
 			return null;
 		} else {
 			throw new Error(`Sound not found: ${src}`);
 		}
+	} else if (src instanceof SoundData) {
+		return src;
+	} else if (src instanceof Asset) {
+		return src.loaded ? src.data : src;
+	} else {
+		throw new Error(`Invalid sound: ${src}`);
 	}
-	// TODO: check type
-	return src;
 }
 
 function resolveShader(
-	src: string | ShaderData | Promise<ShaderData> | undefined
-): ShaderData | Promise<ShaderData> | null {
+	src: string | ShaderData | Asset<ShaderData> | undefined
+): ShaderData | Asset<ShaderData> | null {
 	if (!src) {
 		return gfx.defShader;
 	}
-	if (typeof src === "string" || src instanceof Promise) {
+	if (typeof src === "string") {
 		const shader = getShader(src)
 		if (shader) {
-			return shader;
+			return shader.loaded ? shader.data : shader;
 		} else if (loadProgress() < 1) {
 			return null;
 		} else {
 			throw new Error(`Shader not found: ${src}`);
 		}
+	} else if (src instanceof Asset) {
+		return src.loaded ? src.data : src;
 	}
 	// TODO: check type
 	return src;
 }
 
 function resolveFont(
-	src: string | FontData | Promise<FontData> | undefined
-): FontData | Promise<FontData> {
+	src: string | FontData | Asset<FontData> | undefined
+): FontData | Asset<FontData> | void {
 	if (!src) {
 		return getFont(gopt.font ?? DEF_FONT);
 	}
-	if (typeof src === "string" || src instanceof Promise) {
+	if (typeof src === "string") {
 		const font = getFont(src)
 		if (font) {
-			return font;
+			return font.loaded ? font.data : font;
 		} else if (loadProgress() < 1) {
 			return null;
 		} else {
 			throw new Error(`Font not found: ${src}`);
 		}
+	} else if (src instanceof Asset) {
+		return src.loaded ? src.data : src;
 	}
 	// TODO: check type
 	return src;
@@ -1161,7 +1189,7 @@ function play(
 
 	const snd = resolveSound(src);
 
-	if (snd instanceof Promise) {
+	if (snd instanceof Asset) {
 		const pb = play(new SoundData(createEmptyAudioBuffer()));
 		const doPlay = (snd: SoundData) => {
 			const pb2 = play(snd, opt);
@@ -1169,7 +1197,7 @@ function play(
 				pb[k] = pb2[k];
 			}
 		}
-		snd.then(doPlay)
+		snd.onLoad(doPlay)
 		return pb;
 	} else if (snd === null) {
 		const pb = play(new SoundData(createEmptyAudioBuffer()));
@@ -1479,7 +1507,7 @@ function drawRaw(
 
 	const shader = resolveShader(shaderSrc);
 
-	if (!shader || shader instanceof Promise) {
+	if (!shader || shader instanceof Asset) {
 		return;
 	}
 
@@ -1782,7 +1810,7 @@ function drawSprite(opt: DrawSpriteOpt) {
 
 	const spr = resolveSprite(opt.sprite);
 
-	if (!spr || spr instanceof Promise) {
+	if (!spr || spr instanceof Asset) {
 		return;
 	}
 
@@ -2231,7 +2259,7 @@ function formatText(opt: DrawTextOpt): FormattedText {
 
 	const font = resolveFont(opt.font);
 
-	if (font instanceof Promise) {
+	if (font instanceof Asset) {
 		return {
 			width: 0,
 			height: 0,
@@ -3974,7 +4002,7 @@ interface SpriteCurAnim {
 
 // TODO: clean
 function sprite(
-	src: string | SpriteData | Promise<SpriteData>,
+	src: string | SpriteData | Asset<SpriteData>,
 	opt: SpriteCompOpt = {}
 ): SpriteComp {
 
@@ -4031,7 +4059,7 @@ function sprite(
 
 				const spr = resolveSprite(src);
 
-				if (!spr || spr instanceof Promise) {
+				if (!spr || spr instanceof Asset) {
 					return;
 				}
 
@@ -5499,6 +5527,7 @@ const ctx: KaboomCtx = {
 	getSound,
 	getFont,
 	getShader,
+	Asset,
 	SpriteData,
 	SoundData,
 	// query

--- a/src/types.ts
+++ b/src/types.ts
@@ -2390,6 +2390,7 @@ export declare class Asset<D> {
 	static loaded<D>(data: D): Asset<D>
 	onLoad(action: (data: D) => void): Asset<D>
 	onError(action: (err: Error) => void): Asset<D>
+	onFinish(action: () => void): Asset<D>
 	then(action: (data: D) => void): Asset<D>
 	catch(action: (err: Error) => void): Asset<D>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2383,14 +2383,13 @@ export interface SpriteAtlasEntry {
 }
 
 export declare class Asset<D> {
-	loader: Promise<D>
-	loaded: boolean
+	done: boolean
 	data: D | null
+	error: Error | null
 	constructor(loader: Promise<D>)
 	static loaded<D>(data: D): Asset<D>
 	onLoad(action: (data: D) => void): Asset<D>
 	onError(action: (err: Error) => void): Asset<D>
-	onEnd(action: () => void): Asset<D>
 	then(action: (data: D) => void): Asset<D>
 	catch(action: (err: Error) => void): Asset<D>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -921,7 +921,7 @@ export interface KaboomCtx {
 		name: string | null,
 		src: SpriteLoadSrc,
 		options?: SpriteLoadOpt,
-	): Promise<SpriteData>,
+	): Asset<SpriteData>,
 	/**
 	 * Load sprites from a sprite atlas.
 	 *
@@ -953,7 +953,7 @@ export interface KaboomCtx {
 	loadSpriteAtlas(
 		src: SpriteLoadSrc,
 		data: SpriteAtlasData,
-	): Promise<Record<string, SpriteData>>,
+	): Asset<Record<string, SpriteData>>,
 	/**
 	 * Load sprites from a sprite atlas with URL.
 	 *
@@ -972,7 +972,7 @@ export interface KaboomCtx {
 	loadSpriteAtlas(
 		src: SpriteLoadSrc,
 		url: string,
-	): Promise<Record<string, SpriteData>>,
+	): Asset<Record<string, SpriteData>>,
 	/**
 	 * Load a sprite with aseprite spritesheet json.
 	 *
@@ -985,8 +985,8 @@ export interface KaboomCtx {
 		name: string | null,
 		imgSrc: SpriteLoadSrc,
 		jsonSrc: string
-	): Promise<SpriteData>,
-	loadPedit(name: string, src: string): Promise<SpriteData>,
+	): Asset<SpriteData>,
+	loadPedit(name: string, src: string): Asset<SpriteData>,
 	/**
 	 * Load default sprite "bean".
 	 *
@@ -1000,7 +1000,7 @@ export interface KaboomCtx {
 	 * ])
 	 * ```
 	 */
-	loadBean(name?: string): Promise<SpriteData>,
+	loadBean(name?: string): Asset<SpriteData>,
 	/**
 	 * Load a sound into asset manager, with name and resource url.
 	 *
@@ -1013,7 +1013,7 @@ export interface KaboomCtx {
 	loadSound(
 		name: string | null,
 		src: string,
-	): Promise<SoundData>,
+	): Asset<SoundData>,
 	/**
 	 * Load a bitmap font into asset manager, with name and resource url and infomation on the layout of the bitmap.
 	 *
@@ -1033,7 +1033,7 @@ export interface KaboomCtx {
 		gridWidth: number,
 		gridHeight: number,
 		options?: FontLoadOpt,
-	): Promise<FontData>,
+	): Asset<FontData>,
 	/**
 	 * Load a shader into asset manager with vertex and fragment code / file url.
 	 *
@@ -1059,7 +1059,7 @@ export interface KaboomCtx {
 		vert?: string,
 		frag?: string,
 		isUrl?: boolean,
-	): Promise<ShaderData>,
+	): Asset<ShaderData>,
 	/**
 	 * Add a new loader to wait for before starting the game.
 	 *
@@ -1071,7 +1071,7 @@ export interface KaboomCtx {
 	 * }))
 	 * ```
 	 */
-	load<T>(l: Promise<T>): void,
+	load<T>(l: Promise<T>): Asset<T>,
 	/**
 	 * Get the global asset loading progress (0.0 - 1.0).
 	 *
@@ -1083,25 +1083,25 @@ export interface KaboomCtx {
 	 *
 	 * @since v2001.0
 	 */
-	getSprite(handle: string | Promise<SpriteData>): SpriteData | Promise<SpriteData> | null,
+	getSprite(handle: string): Asset<SpriteData> | void,
 	/**
 	 * Get SoundData from handle.
 	 *
 	 * @since v2001.0
 	 */
-	getSound(handle: string | Promise<SoundData>): SoundData | Promise<SoundData> | null,
+	getSound(handle: string): Asset<SoundData> | void,
 	/**
 	 * Get FontData from handle.
 	 *
 	 * @since v2001.0
 	 */
-	getFont(handle: string | Promise<FontData>): FontData | Promise<FontData> | null,
+	getFont(handle: string): Asset<FontData> | void,
 	/**
 	 * Get ShaderData from handle.
 	 *
 	 * @since v2001.0
 	 */
-	getShader(handle: string | Promise<ShaderData>): ShaderData | Promise<ShaderData> | null,
+	getShader(handle: string): Asset<ShaderData> | void,
 	/**
 	 * Get the width of game.
 	 *
@@ -2380,6 +2380,16 @@ export interface SpriteAtlasEntry {
 	 * Animation configuration.
 	 */
 	anims?: SpriteAnims,
+}
+
+export declare class Asset<D> {
+	loader: Promise<D>
+	loaded: boolean
+	data: D | null
+	constructor(loader: Promise<D>)
+	onLoad(action: (data: D) => void): Asset<D>
+	onError(action: (err: Error) => void): Asset<D>
+	onEnd(action: () => void): Asset<D>
 }
 
 export type SpriteLoadSrc = string | GfxTexData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2387,9 +2387,12 @@ export declare class Asset<D> {
 	loaded: boolean
 	data: D | null
 	constructor(loader: Promise<D>)
+	static loaded<D>(data: D): Asset<D>
 	onLoad(action: (data: D) => void): Asset<D>
 	onError(action: (err: Error) => void): Asset<D>
 	onEnd(action: () => void): Asset<D>
+	then(action: (data: D) => void): Asset<D>
+	catch(action: (err: Error) => void): Asset<D>
 }
 
 export type SpriteLoadSrc = string | GfxTexData;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,13 +18,33 @@ export class IDList<T> extends Map<number, T> {
 	}
 }
 
+export class Event {
+	private handlers: IDList<(...args) => void> = new IDList();
+	add(action: (...args) => void): EventCanceller {
+		return this.handlers.pushd(action);
+	}
+	addOnce(action: (...args) => void): EventCanceller {
+		const cancel = this.add((...args) => {
+			action(...args);
+			cancel();
+		});
+		return cancel;
+	}
+	trigger(...args) {
+		this.handlers.forEach((action) => action(...args));
+	}
+	numListeners(): number {
+		return this.handlers.size;
+	}
+}
+
 export class EventHandler<E = string> {
-	private handlers: Map<E, IDList<(...args) => void>> = new Map();
+	private handlers: Map<E, Event> = new Map();
 	on(name: E, action: (...args) => void): EventCanceller {
 		if (!this.handlers.get(name)) {
-			this.handlers.set(name, new IDList());
+			this.handlers.set(name, new Event());
 		}
-		return this.handlers.get(name).pushd(action);
+		return this.handlers.get(name).add(action);
 	}
 	onOnce(name: E, action: (...args) => void): EventCanceller {
 		const cancel = this.on(name, (...args) => {
@@ -35,11 +55,14 @@ export class EventHandler<E = string> {
 	}
 	trigger(name: E, ...args) {
 		if (this.handlers.get(name)) {
-			this.handlers.get(name).forEach((action) => action(...args));
+			this.handlers.get(name).trigger(...args);
 		}
 	}
 	remove(name: E) {
 		this.handlers.delete(name);
+	}
+	numListeners(name: E): number {
+		return this.handlers.get(name)?.numListeners() ?? 0;
 	}
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ export class IDList<T> extends Map<number, T> {
 	}
 }
 
+// TODO: typed event arguments
 export class Event {
 	private handlers: IDList<(...args) => void> = new IDList();
 	add(action: (...args) => void): EventCanceller {


### PR DESCRIPTION
Enables:

```js
const spr = loadSprite("me", "src/me.png")

// multiple onLoad / onError events
spr.onLoad(() => {
    debug.log("hi")
})

spr.onLoad(() => {
    debug.log("hi again!")
})

spr.onError((err) => {
    debug.log("oh no!")
}).onError((err) => {
    debug.log("oh no again!")
})

spr.done // Query the state
spr.error // or access the error if threw
spr.data // Get the asset data directly from the handle

// can use the handle directly 
add([ sprite(spr) ])

drawSprite(() => {
    sprite: spr
})
```