### PR TITLE
Convert non bitmap fonts to bitmap fonts on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - added `download()`, `downloadText()`, `downloadJSON()`, `downloadBlob()`
 - added `Recording#stop()` to stop the recording and returns the video data as mp4 Blob
 - added `debug.numFrames()` to get the total number of frames elapsed
+- fixed visual artifacts on text
 
 ### v2000.2.6
 

--- a/demo/.eslintrc.json
+++ b/demo/.eslintrc.json
@@ -11,7 +11,7 @@
 		"sourceType": "module"
 	},
 	"rules": {
-		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
+		"indent": [ "error", "tab", { "SwitchCase": 1, "ignoreComments": true } ],
 		"linebreak-style": [ "error", "unix" ],
 		"quotes": [ "error", "double" ],
 		"semi": [ "error", "never" ],

--- a/demo/draw.js
+++ b/demo/draw.js
@@ -79,11 +79,6 @@ function drawStuff() {
 			rgb(w(128, 255, 8), w(128, 255, 4), 255),
 			rgb(255, 128, w(128, 255, 4)),
 			rgb(w(128, 255, 8), w(128, 255, 4), 128),
-			// 			Color.RED,
-			// 			Color.BLUE,
-			// 			Color.YELLOW,
-			// 			Color.CYAN,
-			// 			Color.GREEN,
 		],
 		outline,
 	})

--- a/demo/text.js
+++ b/demo/text.js
@@ -41,7 +41,7 @@ const input = add([
 		// The height of character
 		size: curSize,
 		// Text alignment ("left", "center", "right", default "left")
-		align: "center",
+		align: "left",
 		lineSpacing: 8,
 		letterSpacing: 4,
 		// Transform each character for special effects

--- a/demo/text.js
+++ b/demo/text.js
@@ -20,6 +20,7 @@ const builtinFonts = [
 const fonts = [
 	...builtinFonts,
 	"unscii",
+// 	"FROGBLOCK",
 	"Sans-Serif",
 // 	"zpix",
 ]

--- a/demo/text.js
+++ b/demo/text.js
@@ -41,7 +41,7 @@ const input = add([
 		// The height of character
 		size: curSize,
 		// Text alignment ("left", "center", "right", default "left")
-		align: "left",
+		align: "center",
 		lineSpacing: 8,
 		letterSpacing: 4,
 		// Transform each character for special effects

--- a/demo/text.js
+++ b/demo/text.js
@@ -41,7 +41,7 @@ const input = add([
 		// The height of character
 		size: curSize,
 		// Text alignment ("left", "center", "right", default "left")
-		// align: "center",
+		align: "left",
 		lineSpacing: 8,
 		letterSpacing: 4,
 		// Transform each character for special effects

--- a/demo/text.js
+++ b/demo/text.js
@@ -20,7 +20,7 @@ const builtinFonts = [
 const fonts = [
 	...builtinFonts,
 	"unscii",
-	"FROGBLOCK",
+	"Sans-Serif",
 // 	"zpix",
 ]
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -247,6 +247,7 @@ const MAX_DETUNE = 1200
 const DEF_ORIGIN = "topleft"
 const DEF_GRAVITY = 1600
 const BG_GRID_SIZE = 64
+const TEXT_QUAD_PAD = 0.05
 
 const DEF_FONT = "apl386o"
 const DBG_FONT = "sink"
@@ -2526,11 +2527,12 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						tex: font.tex,
 						width: q.w,
 						height: q.h,
+						// without some padding there'll be visual artifacts on edges
 						quad: new Quad(
-							q.x / font.tex.width,
-							q.y / font.tex.height,
-							q.w / font.tex.width,
-							q.h / font.tex.height,
+							(q.x + TEXT_QUAD_PAD) / font.tex.width,
+							(q.y + TEXT_QUAD_PAD) / font.tex.height,
+							(q.w - TEXT_QUAD_PAD * 2) / font.tex.width,
+							(q.h - TEXT_QUAD_PAD * 2) / font.tex.height,
 						),
 						ch: ch,
 						pos: vec2(curX, th),
@@ -2561,7 +2563,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			width: curX - letterSpacing,
 			chars: curLine,
 		})
-		console.log(lines)
 
 		th += size
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2434,7 +2434,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 					c2d.textAlign = "left"
 					c2d.fillStyle = "rgb(255, 255, 255)"
 					c2d.fillText(ch, 0, 0)
-					const w = Math.ceil(c2d.measureText(ch).width)
+					const m = c2d.measureText(ch)
+					const w = Math.ceil(m.width)
 					const img = c2d.getImageData(0, 0, w, font.size)
 
 					// if we are about to exceed the X axis of the texture, go to another line
@@ -2570,9 +2571,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			tw = opt.width
 		}
 
-		let idx = 0
 		const fchars: FormattedChar[] = []
-		const offset = vec2(0)
 
 		lines.forEach((line, ln) => {
 
@@ -2581,11 +2580,12 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			line.chars.forEach((fchar, cn) => {
 
 				const q = font.map[fchar.ch]
+				const idx = fchars.length
 
-				if (idx === 0) {
-					offset.x = q.w * scale.x * 0.5
-					offset.y = q.h * scale.y * 0.5
-				}
+				const offset = new Vec2(
+					q.w * scale.x * 0.5,
+					q.h * scale.y * 0.5,
+				)
 
 				fchar.pos = fchar.pos.add(ox, 0).add(offset)
 
@@ -2612,8 +2612,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				}
 
 				fchars.push(fchar)
-
-				idx += 1
 
 			})
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2573,11 +2573,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 		const fchars: FormattedChar[] = []
 
-		lines.forEach((line, ln) => {
+		for (const line of lines) {
 
 			const ox = (tw - line.width) * alignPt(opt.align ?? "left")
 
-			line.chars.forEach((fchar, cn) => {
+			for (const fchar of line.chars) {
 
 				const q = font.map[fchar.ch]
 				const idx = fchars.length
@@ -2613,9 +2613,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 				fchars.push(fchar)
 
-			})
+			}
 
-		})
+		}
 
 		return {
 			width: tw,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2399,6 +2399,7 @@ export interface LoadSpriteOpt {
 	sliceY?: number,
 	anims?: SpriteAnims,
 	filter?: TexFilter,
+	wrap?: TexWrap,
 }
 
 export type SpriteAtlasData = Record<string, SpriteAtlasEntry>
@@ -2591,6 +2592,7 @@ export interface GfxShader {
 
 export type TextureOpt = {
 	filter?: TexFilter,
+	wrap?: TexWrap,
 }
 
 export declare class Texture {
@@ -2622,6 +2624,7 @@ export interface Vertex {
  * Texture scaling filter. "nearest" is mainly for sharp pixelated scaling, "linear" means linear interpolation.
  */
 export type TexFilter = "nearest" | "linear"
+export type TexWrap = "repeat" | "clampToEdge"
 
 /**
  * Common render properties.
@@ -3024,11 +3027,11 @@ export type FormattedText = {
  * One formated character.
  */
 export interface FormattedChar {
+	ch: string,
 	tex: Texture,
 	width: number,
 	height: number,
 	quad: Quad,
-	ch: string,
 	pos: Vec2,
 	scale: Vec2,
 	angle: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2452,14 +2452,14 @@ export declare class Asset<D> {
 	finally(action: () => void): Asset<D>
 }
 
-export type LoadSpriteSrc = string | GfxTexData
+export type LoadSpriteSrc = string | TexImageSource
 
 export declare class SpriteData {
-	tex: GfxTexture
+	tex: Texture
 	frames: Quad[]
 	anims: SpriteAnims
-	constructor(tex: GfxTexture, frames?: Quad[], anims?: SpriteAnims)
-	static fromImage(data: GfxTexData, opt?: LoadSpriteOpt): SpriteData
+	constructor(tex: Texture, frames?: Quad[], anims?: SpriteAnims)
+	static fromImage(data: TexImageSource, opt?: LoadSpriteOpt): SpriteData
 	static fromURL(url: string, opt?: LoadSpriteOpt): Promise<SpriteData>
 }
 
@@ -2591,23 +2591,25 @@ export interface GfxShader {
 	free(): void,
 }
 
-// TODO: hide
-export interface GfxTexture {
-	width: number,
-	height: number,
-	bind(): void,
-	unbind(): void,
-	free(): void,
+export type TextureOpt = {
+	filter?: TexFilter,
+	wrap?: TexWrap,
 }
 
-export type GfxTexData =
-	HTMLImageElement
-	| HTMLCanvasElement
-	| ImageData
-	| ImageBitmap
+export declare class Texture {
+	glTex: WebGLTexture
+	width: number
+	height: number
+	constructor(w: number, h: number, opt?: TextureOpt)
+	static fromImage(img: TexImageSource, opt?: TextureOpt): Texture
+	update(w: number, h: number, data: ArrayBufferView)
+	bind()
+	unbind()
+	free()
+}
 
 export interface GfxFont {
-	tex: GfxTexture,
+	tex: Texture,
 	map: Record<string, Quad>,
 	size: number,
 }
@@ -2701,7 +2703,7 @@ export type DrawUVQuadOpt = RenderProps & {
 	/**
 	 * The texture to sample for this quad.
 	 */
-	tex?: GfxTexture,
+	tex?: Texture,
 	/**
 	 * The texture sampling area.
 	 */
@@ -3026,7 +3028,7 @@ export type FormattedText = {
  * One formated character.
  */
 export interface FormattedChar {
-	tex: GfxTexture,
+	tex: Texture,
 	width: number,
 	height: number,
 	quad: Quad,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2399,7 +2399,6 @@ export interface LoadSpriteOpt {
 	sliceY?: number,
 	anims?: SpriteAnims,
 	filter?: TexFilter,
-	wrap?: TexWrap,
 }
 
 export type SpriteAtlasData = Record<string, SpriteAtlasEntry>
@@ -2473,7 +2472,6 @@ export declare class SoundData {
 export interface LoadBitmapFontOpt {
 	chars?: string,
 	filter?: TexFilter,
-	wrap?: TexWrap,
 }
 
 export interface SoundData {
@@ -2593,7 +2591,6 @@ export interface GfxShader {
 
 export type TextureOpt = {
 	filter?: TexFilter,
-	wrap?: TexWrap,
 }
 
 export declare class Texture {
@@ -2625,7 +2622,6 @@ export interface Vertex {
  * Texture scaling filter. "nearest" is mainly for sharp pixelated scaling, "linear" means linear interpolation.
  */
 export type TexFilter = "nearest" | "linear"
-export type TexWrap = "repeat" | "clampToEdge"
 
 /**
  * Common render properties.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2602,7 +2602,7 @@ export declare class Texture {
 	height: number
 	constructor(w: number, h: number, opt?: TextureOpt)
 	static fromImage(img: TexImageSource, opt?: TextureOpt): Texture
-	update(w: number, h: number, data: ArrayBufferView)
+	update(x: number, y: number, img: TexImageSource)
 	bind()
 	unbind()
 	free()

--- a/src/types.ts
+++ b/src/types.ts
@@ -2608,12 +2608,8 @@ export type GfxTexData =
 
 export interface GfxFont {
 	tex: GfxTexture,
-	map: Record<string, Vec2>,
-	/**
-	 * The quad width of each character.
-	 */
-	qw: number,
-	qh: number,
+	map: Record<string, Quad>,
+	size: number,
 }
 
 export interface Vertex {
@@ -3022,29 +3018,24 @@ export type DrawTextOpt = RenderProps & {
 export type FormattedText = {
 	width: number,
 	height: number,
-} & ({
-	isBitmap: true,
 	chars: FormattedChar[],
-} | {
-	isBitmap: false,
-	tex: GfxTexture,
 	opt: DrawTextOpt,
-})
+}
 
 /**
  * One formated character.
  */
 export interface FormattedChar {
 	tex: GfxTexture,
+	width: number,
+	height: number,
 	quad: Quad,
 	ch: string,
 	pos: Vec2,
 	scale: Vec2,
 	angle: number,
 	color: Color,
-	fixed: boolean,
 	opacity: number,
-	uniform: Uniform,
 }
 
 /**


### PR DESCRIPTION
Build a texture atlas on the go. When see uncached character, use canvas 2d to draw that character to offscreen canvas, `getImageData()` and upload image to a 1024x1024 texture atlas and store / cache the quad data to a map similar to bitmap font.

The result looks kinda decent (image below using built-in `"Sans-Serif"` font)
<img width="695" alt="1644812978" src="https://user-images.githubusercontent.com/9929523/153800277-d17a333e-556e-4ca2-9fde-87111508c64a.png">

Also had to refactor the text formatting logic a bit to support variant width characters