### PR TITLE
Improve error handling screen, allow register error event or customize error screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - added `Recording#stop()` to stop the recording and returns the video data as mp4 Blob
 - added `debug.numFrames()` to get the total number of frames elapsed
 - fixed visual artifacts on text
+- added `onError()` to handle error or even custom error screen
 
 ### v2000.2.6
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -5570,58 +5570,61 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		enterBurpMode()
 	}
 
-	let errHandler = (err: Error) => {
-
-		// TODO: better tool for drawing without app.scale
-		pushTransform()
-		pushScale(1 / app.scale)
-
-		const pad = 32
-		const gap = 16
-		const gw = width() * app.scale
-		const gh = height() * app.scale
-
-		const textStyle = {
-			size: 24,
-			width: gw - pad * 2,
-			letterSpacing: 4,
-			lineSpacing: 4,
-			font: DBG_FONT,
-		}
-
-		drawRect({
-			width: gw,
-			height: gh,
-			color: rgb(0, 0, 255),
-		})
-
-		const title = formatText({
-			...textStyle,
-			text: err.name,
-			pos: vec2(pad),
-			color: rgb(255, 128, 0),
-		})
-
-		drawFormattedText(title)
-
-		drawText({
-			...textStyle,
-			text: err.message,
-			pos: vec2(pad, pad + title.height + gap),
-		})
-
-		popTransform()
-
-	}
-
 	function onError(action: (err: Error) => void) {
-		errHandler = action
+		game.ev.on("error", action)
 	}
 
 	function handleErr(err: Error) {
-		run(() => errHandler(err))
+
+		run(() => {
+
+			// TODO: better tool for drawing without app.scale
+			pushTransform()
+			pushScale(1 / app.scale)
+
+			const pad = 32
+			const gap = 16
+			const gw = width() * app.scale
+			const gh = height() * app.scale
+
+			const textStyle = {
+				size: 24,
+				width: gw - pad * 2,
+				letterSpacing: 4,
+				lineSpacing: 4,
+				font: DBG_FONT,
+			}
+
+			drawRect({
+				width: gw,
+				height: gh,
+				color: rgb(0, 0, 255),
+			})
+
+			const title = formatText({
+				...textStyle,
+				text: err.name,
+				pos: vec2(pad),
+				color: rgb(255, 128, 0),
+			})
+
+			drawFormattedText(title)
+
+			drawText({
+				...textStyle,
+				text: err.message,
+				pos: vec2(pad, pad + title.height + gap),
+			})
+
+			popTransform()
+			game.ev.trigger("error", err)
+
+		})
+
+		// only run that once
 		app.stopped = true
 		cancelAnimationFrame(app.loopID)
+
 	}
 
 	function run(f: () => void) {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -5342,6 +5342,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	}
 
+	// TODO: reset transform
 	function drawDebug() {
 
 		if (debug.inspect) {
@@ -5569,9 +5570,58 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		enterBurpMode()
 	}
 
+	let errHandler = (err: Error) => {
+
+		// TODO: better tool for drawing without app.scale
+		pushTransform()
+		pushScale(1 / app.scale)
+
+		const pad = 32
+		const gap = 16
+		const gw = width() * app.scale
+		const gh = height() * app.scale
+
+		const textStyle = {
+			size: 24,
+			width: gw - pad * 2,
+			letterSpacing: 4,
+			lineSpacing: 4,
+			font: DBG_FONT,
+		}
+
+		drawRect({
+			width: gw,
+			height: gh,
+			color: rgb(0, 0, 255),
+		})
+
+		const title = formatText({
+			...textStyle,
+			text: err.name,
+			pos: vec2(pad),
+			color: rgb(255, 128, 0),
+		})
+
+		drawFormattedText(title)
+
+		drawText({
+			...textStyle,
+			text: err.message,
+			pos: vec2(pad, pad + title.height + gap),
+		})
+
+		popTransform()
+
+	}
+
+	function onError(action: (err: Error) => void) {
+		errHandler = action
+	}
+
 	function handleErr(err: Error) {
-		debug.log(err)
-		run(drawDebug)
+		run(() => errHandler(err))
+		app.stopped = true
+		cancelAnimationFrame(app.loopID)
 	}
 
 	function run(f: () => void) {
@@ -5774,6 +5824,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		fullscreen,
 		isFullscreen,
 		onLoad,
+		onError,
 		isTouch: () => app.isTouch,
 		// misc
 		camPos,

--- a/src/types.ts
+++ b/src/types.ts
@@ -707,6 +707,12 @@ export interface KaboomCtx {
 	 */
 	onLoad(action: () => void): void,
 	/**
+	 * Register a custom error handler. Can be used to draw a custom error screen.
+	 *
+	 * @since v2001.0
+	 */
+	onError(action: (err: Error) => void): void,
+	/**
 	 * Register an event that runs when 2 game objs with certain tags collides (required to have area() component).
 	 *
 	 * @since v2000.1


### PR DESCRIPTION
Added an error screen like this

<img width="750" alt="1644869632" src="https://user-images.githubusercontent.com/9929523/153941321-4883af17-a7ea-4afa-b1df-7903058d47f2.png">

also added 

```js
onError((err: Error) => {
    // ...
})
```

error handling, or even custom error screen