### PR TITLE
Add generic texture coordinate padding to remove rendering artifacts

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -251,7 +251,8 @@ const DEF_FONT = "apl386o"
 const DBG_FONT = "sink"
 const DEF_TEXT_SIZE = 64
 const FONT_ATLAS_SIZE = 1024
-const TEXT_QUAD_PAD = 0.05
+// 0.05 pixel padding to quads to prevent artifact
+const QUAD_PAD = 0.05
 
 const LOG_MAX = 1
 
@@ -1024,6 +1025,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		const qh = h / y
 		for (let j = 0; j < y; j++) {
 			for (let i = 0; i < x; i++) {
+				// TODO: apply QUAD_PAD
 				frames.push(new Quad(
 					dx + i * qw,
 					dy + j * qh,
@@ -1130,10 +1132,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			const size = data.meta.size
 			spr.frames = data.frames.map((f: any) => {
 				return new Quad(
-					f.frame.x / size.w,
-					f.frame.y / size.h,
-					f.frame.w / size.w,
-					f.frame.h / size.h,
+					(f.frame.x + QUAD_PAD) / size.w,
+					(f.frame.y + QUAD_PAD) / size.h,
+					(f.frame.w - QUAD_PAD * 2) / size.w,
+					(f.frame.h - QUAD_PAD * 2) / size.h,
 				)
 			})
 			for (const anim of data.meta.frameTags) {
@@ -2552,10 +2554,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						height: q.h,
 						// without some padding there'll be visual artifacts on edges
 						quad: new Quad(
-							(q.x + TEXT_QUAD_PAD) / font.tex.width,
-							(q.y + TEXT_QUAD_PAD) / font.tex.height,
-							(q.w - TEXT_QUAD_PAD * 2) / font.tex.width,
-							(q.h - TEXT_QUAD_PAD * 2) / font.tex.height,
+							(q.x + QUAD_PAD) / font.tex.width,
+							(q.y + QUAD_PAD) / font.tex.height,
+							(q.w - QUAD_PAD * 2) / font.tex.width,
+							(q.h - QUAD_PAD * 2) / font.tex.height,
 						),
 						ch: ch,
 						pos: vec2(curX, th),

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1851,37 +1851,25 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		drawRaw([
 			{
 				pos: vec3(-w / 2, h / 2, 0),
-				uv: vec2(
-					opt.flipX ? qx + qw : qx,
-					opt.flipY ? qy : qy + qh,
-				),
+				uv: vec2(opt.flipX ? qx + qw : qx, opt.flipY ? qy : qy + qh),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(-w / 2, -h / 2, 0),
-				uv: vec2(
-					opt.flipX ? qx + qw : qx,
-					opt.flipY ? qy + qh : qy,
-				),
+				uv: vec2(opt.flipX ? qx + qw : qx, opt.flipY ? qy + qh : qy),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(w / 2, -h / 2, 0),
-				uv: vec2(
-					opt.flipX ? qx : qx + qw,
-					opt.flipY ? qy + qh : qy,
-				),
+				uv: vec2(opt.flipX ? qx : qx + qw, opt.flipY ? qy + qh : qy),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(w / 2, h / 2, 0),
-				uv: vec2(
-					opt.flipX ? qx : qx + qw,
-					opt.flipY ? qy : qy + qh,
-				),
+				uv: vec2(opt.flipX ? qx : qx + qw, opt.flipY ? qy : qy + qh),
 				color: color,
 				opacity: opacity,
 			},

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -251,8 +251,8 @@ const DEF_FONT = "apl386o"
 const DBG_FONT = "sink"
 const DEF_TEXT_SIZE = 64
 const FONT_ATLAS_SIZE = 1024
-// 0.05 pixel padding to quads to prevent artifact
-const QUAD_PAD = 0.05
+// 0.05 pixel padding to texture coordinates to prevent artifact
+const UV_PAD = 0.05
 
 const LOG_MAX = 1
 
@@ -1835,8 +1835,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		const opacity = opt.opacity ?? 1
 
 		// apply uv padding to avoid artifacts
-		const uvPadX = opt.tex ? QUAD_PAD / opt.tex.width : 0
-		const uvPadY = opt.tex ? QUAD_PAD / opt.tex.height : 0
+		const uvPadX = opt.tex ? UV_PAD / opt.tex.width : 0
+		const uvPadY = opt.tex ? UV_PAD / opt.tex.height : 0
 		const qx = q.x + uvPadX
 		const qy = q.y + uvPadY
 		const qw = q.w - uvPadX * 2

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -738,7 +738,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		static fromImage(data: TexImageSource, opt: LoadSpriteOpt = {}): SpriteData {
 			return new SpriteData(
 				Texture.fromImage(data, opt),
-				slice(opt.sliceX || 1, opt.sliceY || 1),
+				slice(opt.sliceX || 1, opt.sliceY || 1, 0, 0, 1, 1, data.width, data.height),
 				opt.anims ?? {},
 			)
 		}
@@ -1019,18 +1019,20 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	// get an array of frames based on configuration on how to slice the image
-	function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1): Quad[] {
+	function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1, tw = null, th = null): Quad[] {
 		const frames = []
 		const qw = w / x
 		const qh = h / y
+		const padx = tw ? QUAD_PAD / tw : 0
+		const pady = th ? QUAD_PAD / th : 0
 		for (let j = 0; j < y; j++) {
 			for (let i = 0; i < x; i++) {
 				// TODO: apply QUAD_PAD
 				frames.push(new Quad(
-					dx + i * qw,
-					dy + j * qh,
-					qw,
-					qh,
+					dx + i * qw + padx,
+					dy + j * qh + pady,
+					qw - padx * 2,
+					qh - pady * 2,
 				))
 			}
 		}
@@ -1063,6 +1065,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						info.y / h,
 						info.width / w,
 						info.height / h,
+						w,
+						h,
 					),
 					info.anims,
 				)

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1062,8 +1062,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						info.y / h,
 						info.width / w,
 						info.height / h,
-						w,
-						h,
 					),
 					info.anims,
 				)

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1023,16 +1023,13 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		const frames = []
 		const qw = w / x
 		const qh = h / y
-		const padx = tw ? QUAD_PAD / tw : 0
-		const pady = th ? QUAD_PAD / th : 0
 		for (let j = 0; j < y; j++) {
 			for (let i = 0; i < x; i++) {
-				// TODO: apply QUAD_PAD
 				frames.push(new Quad(
-					dx + i * qw + padx,
-					dy + j * qh + pady,
-					qw - padx * 2,
-					qh - pady * 2,
+					dx + i * qw,
+					dy + j * qh,
+					qw,
+					qh,
 				))
 			}
 		}
@@ -1136,10 +1133,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			const size = data.meta.size
 			spr.frames = data.frames.map((f: any) => {
 				return new Quad(
-					(f.frame.x + QUAD_PAD) / size.w,
-					(f.frame.y + QUAD_PAD) / size.h,
-					(f.frame.w - QUAD_PAD * 2) / size.w,
-					(f.frame.h - QUAD_PAD * 2) / size.h,
+					f.frame.x / size.w,
+					f.frame.y / size.h,
+					f.frame.w / size.w,
+					f.frame.h / size.h,
 				)
 			})
 			for (const anim of data.meta.frameTags) {
@@ -1839,6 +1836,14 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		const color = opt.color || rgb(255, 255, 255)
 		const opacity = opt.opacity ?? 1
 
+		// apply uv padding to avoid artifacts
+		const uvPadX = opt.tex ? QUAD_PAD / opt.tex.width : 0
+		const uvPadY = opt.tex ? QUAD_PAD / opt.tex.height : 0
+		const qx = q.x + uvPadX
+		const qy = q.y + uvPadY
+		const qw = q.w - uvPadX * 2
+		const qh = q.h - uvPadY * 2
+
 		pushTransform()
 		pushTranslate(opt.pos)
 		pushRotateZ(opt.angle)
@@ -1848,25 +1853,37 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		drawRaw([
 			{
 				pos: vec3(-w / 2, h / 2, 0),
-				uv: vec2(opt.flipX ? q.x + q.w : q.x, opt.flipY ? q.y : q.y + q.h),
+				uv: vec2(
+					opt.flipX ? qx + qw : qx,
+					opt.flipY ? qy : qy + qh,
+				),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(-w / 2, -h / 2, 0),
-				uv: vec2(opt.flipX ? q.x + q.w : q.x, opt.flipY ? q.y + q.h : q.y),
+				uv: vec2(
+					opt.flipX ? qx + qw : qx,
+					opt.flipY ? qy + qh : qy,
+				),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(w / 2, -h / 2, 0),
-				uv: vec2(opt.flipX ? q.x : q.x + q.w, opt.flipY ? q.y + q.h : q.y),
+				uv: vec2(
+					opt.flipX ? qx : qx + qw,
+					opt.flipY ? qy + qh : qy,
+				),
 				color: color,
 				opacity: opacity,
 			},
 			{
 				pos: vec3(w / 2, h / 2, 0),
-				uv: vec2(opt.flipX ? q.x : q.x + q.w, opt.flipY ? q.y : q.y + q.h),
+				uv: vec2(
+					opt.flipX ? qx : qx + qw,
+					opt.flipY ? qy : qy + qh,
+				),
 				color: color,
 				opacity: opacity,
 			},
@@ -2558,10 +2575,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						height: q.h,
 						// without some padding there'll be visual artifacts on edges
 						quad: new Quad(
-							(q.x + QUAD_PAD) / font.tex.width,
-							(q.y + QUAD_PAD) / font.tex.height,
-							(q.w - QUAD_PAD * 2) / font.tex.width,
-							(q.h - QUAD_PAD * 2) / font.tex.height,
+							q.x / font.tex.width,
+							q.y / font.tex.height,
+							q.w / font.tex.width,
+							q.h / font.tex.height,
 						),
 						ch: ch,
 						pos: vec2(curX, th),

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -738,7 +738,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		static fromImage(data: TexImageSource, opt: LoadSpriteOpt = {}): SpriteData {
 			return new SpriteData(
 				Texture.fromImage(data, opt),
-				slice(opt.sliceX || 1, opt.sliceY || 1, 0, 0, 1, 1, data.width, data.height),
+				slice(opt.sliceX || 1, opt.sliceY || 1),
 				opt.anims ?? {},
 			)
 		}
@@ -1019,7 +1019,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	// get an array of frames based on configuration on how to slice the image
-	function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1, tw = null, th = null): Quad[] {
+	function slice(x = 1, y = 1, dx = 0, dy = 0, w = 1, h = 1): Quad[] {
 		const frames = []
 		const qw = w / x
 		const qh = h / y


### PR DESCRIPTION
Before:
<img width="593" alt="1645756717" src="https://user-images.githubusercontent.com/9929523/155643542-f4f1b1a2-b409-401e-8083-9d72f33a24d6.png">
After:
<img width="600" alt="1645756729" src="https://user-images.githubusercontent.com/9929523/155643544-e85c52ec-3d23-454d-9d5f-176aa60d1aec.png">


Removes the hard coded padding for text, added generic padding to `drawUVQuad()` which applies to anything that uses texture like sprites. The padding is a workaround to floating point imprecision (the uv coordinates are all very small floating point values, which I guess is the problem)