### PR TITLE
Use separate package for global type declarations

### DIFF
--- a/pkgs/global/generate.js
+++ b/pkgs/global/generate.js
@@ -4,7 +4,7 @@ import ts from "typescript"
 
 const f = ts.createSourceFile(
 	"ts",
-	fs.readFileSync("../../src/types.ts", "utf-8"),
+	fs.readFileSync("node_modules/kaboom/src/types.ts", "utf-8"),
 	ts.ScriptTarget.Latest,
 	true,
 )

--- a/pkgs/global/generate.js
+++ b/pkgs/global/generate.js
@@ -1,0 +1,159 @@
+import fs from "fs"
+import path from "path"
+import ts from "typescript"
+
+const f = ts.createSourceFile(
+	"ts",
+	fs.readFileSync("../../src/types.ts", "utf-8"),
+	ts.ScriptTarget.Latest,
+	true,
+)
+
+function transform(o, f) {
+	for (const k in o) {
+		if (o[k] == null) {
+			continue
+		}
+		const v = f(k, o[k])
+		if (v != null) {
+			o[k] = v
+		} else {
+			delete o[k]
+		}
+		if (typeof o[k] === "object") {
+			transform(o[k], f)
+		}
+	}
+	return o
+}
+
+// transform and prune typescript ast to a format more meaningful to us
+const stmts = transform(f.statements, (k, v) => {
+	switch (k) {
+		case "end":
+		case "flags":
+		case "parent":
+		case "modifiers":
+		case "transformFlags":
+		case "modifierFlagsCache": return
+		case "name":
+		case "typeName":
+		case "tagName": return v.escapedText
+		case "pos": return typeof v === "number" ? undefined : v
+		case "kind": return ts.SyntaxKind[v]
+		case "questionToken": return true
+		case "members": {
+			const members = {}
+			for (const mem of v) {
+				const name = mem.name?.escapedText
+				if (!name || name === "toString") {
+					continue
+				}
+				if (!members[name]) {
+					members[name] = []
+				}
+				members[name].push(mem)
+			}
+			return members
+		}
+		case "jsDoc": {
+			const doc = v[0]
+			const taglist = doc.tags ?? []
+			const tags = {}
+			for (const tag of taglist) {
+				const name = tag.tagName.escapedText
+				if (!tags[name]) {
+					tags[name] = []
+				}
+				tags[name].push(tag.comment)
+			}
+			return {
+				doc: doc.comment,
+				tags: tags,
+			}
+		}
+		default: return v
+	}
+})
+
+// check if global defs are being generated
+let globalGenerated = false
+
+// window attribs to overwrite
+const overwrites = new Set([
+	"origin",
+	"focus",
+])
+
+// contain the type data for doc gen
+const types = {}
+const sections = [{
+	name: "Start",
+	entries: [ "kaboom" ],
+}]
+
+let dts = ""
+
+dts += `import { KaboomCtx } from "kaboom"\n`
+
+// generate global decls for KaboomCtx members
+dts += "declare global {\n"
+
+for (const stmt of stmts) {
+
+	if (!types[stmt.name]) {
+		types[stmt.name] = []
+	}
+
+	types[stmt.name].push(stmt)
+
+	if (stmt.name === "KaboomCtx") {
+
+		if (stmt.kind !== "InterfaceDeclaration") {
+			throw new Error("KaboomCtx must be an interface.")
+		}
+
+		for (const name in stmt.members) {
+
+			const mem = stmt.members[name]
+
+			if (overwrites.has(name)) {
+				dts += "\t// @ts-ignore\n"
+			}
+
+			dts += `\tconst ${name}: KaboomCtx["${name}"]\n`
+
+			const tags = mem[0].jsDoc?.tags ?? {}
+
+			if (tags["section"]) {
+				const name = tags["section"][0]
+				const docPath = path.resolve(`doc/sections/${name}.md`)
+				sections.push({
+					name: name,
+					entries: [],
+					doc: fs.existsSync(docPath) ? fs.readFileSync(docPath, "utf8") : null,
+				})
+			}
+
+			const curSection = sections[sections.length - 1]
+
+			if (name && !curSection.entries.includes(name)) {
+				curSection.entries.push(name)
+			}
+
+		}
+
+		globalGenerated = true
+
+	}
+
+}
+
+dts += "}\n"
+
+if (!globalGenerated) {
+	throw new Error("KaboomCtx not found, failed to generate global defs.")
+}
+
+fs.writeFileSync("dist/kaboomGlobal.d.ts", dts)
+console.log("-> dist/kaboomGlobal.d.ts")

--- a/pkgs/global/package-lock.json
+++ b/pkgs/global/package-lock.json
@@ -1,34 +1,25 @@
 {
-	"name": "kaboom-globals",
-	"version": "1.2.1",
+	"name": "kaboom-global",
+	"version": "2001.0.0-alpha.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "kaboom-globals",
-			"version": "1.2.1",
-			"license": "MIT",
-			"devDependencies": {
-				"kaboom": "file:../..",
-				"typescript": "^4.6.3"
-			}
-		},
-		"../..": {
+			"name": "kaboom-global",
 			"version": "2001.0.0-alpha.21",
-			"dev": true,
 			"license": "MIT",
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.14.0",
-				"esbuild": "^0.14.21",
-				"eslint": "^8.10.0",
-				"express": "^4.17.3",
-				"puppeteer": "^13.5.1",
-				"typescript": "^4.6.2"
+				"typescript": "^4.6.3"
+			},
+			"peerDependencies": {
+				"kaboom": "2001.0.0-alpha.21"
 			}
 		},
 		"node_modules/kaboom": {
-			"resolved": "../..",
-			"link": true
+			"version": "2001.0.0-alpha.21",
+			"resolved": "https://registry.npmjs.org/kaboom/-/kaboom-2001.0.0-alpha.21.tgz",
+			"integrity": "sha512-fwxZzVjhaSIUxQdEbNKDMVjHcU2AllRiy4u/BKNd1ww/gZMdC1IA64qWLVUWWS02R7VSLd70umFYJof3R7CvOg==",
+			"peer": true
 		},
 		"node_modules/typescript": {
 			"version": "4.6.3",
@@ -46,15 +37,10 @@
 	},
 	"dependencies": {
 		"kaboom": {
-			"version": "file:../..",
-			"requires": {
-				"@typescript-eslint/eslint-plugin": "^5.14.0",
-				"esbuild": "^0.14.21",
-				"eslint": "^8.10.0",
-				"express": "^4.17.3",
-				"puppeteer": "^13.5.1",
-				"typescript": "^4.6.2"
-			}
+			"version": "2001.0.0-alpha.21",
+			"resolved": "https://registry.npmjs.org/kaboom/-/kaboom-2001.0.0-alpha.21.tgz",
+			"integrity": "sha512-fwxZzVjhaSIUxQdEbNKDMVjHcU2AllRiy4u/BKNd1ww/gZMdC1IA64qWLVUWWS02R7VSLd70umFYJof3R7CvOg==",
+			"peer": true
 		},
 		"typescript": {
 			"version": "4.6.3",

--- a/pkgs/global/package-lock.json
+++ b/pkgs/global/package-lock.json
@@ -1,0 +1,66 @@
+{
+	"name": "kaboom-globals",
+	"version": "1.2.1",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "kaboom-globals",
+			"version": "1.2.1",
+			"license": "MIT",
+			"devDependencies": {
+				"kaboom": "file:../..",
+				"typescript": "^4.6.3"
+			}
+		},
+		"../..": {
+			"version": "2001.0.0-alpha.21",
+			"dev": true,
+			"license": "MIT",
+			"devDependencies": {
+				"@typescript-eslint/eslint-plugin": "^5.14.0",
+				"esbuild": "^0.14.21",
+				"eslint": "^8.10.0",
+				"express": "^4.17.3",
+				"puppeteer": "^13.5.1",
+				"typescript": "^4.6.2"
+			}
+		},
+		"node_modules/kaboom": {
+			"resolved": "../..",
+			"link": true
+		},
+		"node_modules/typescript": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		}
+	},
+	"dependencies": {
+		"kaboom": {
+			"version": "file:../..",
+			"requires": {
+				"@typescript-eslint/eslint-plugin": "^5.14.0",
+				"esbuild": "^0.14.21",
+				"eslint": "^8.10.0",
+				"express": "^4.17.3",
+				"puppeteer": "^13.5.1",
+				"typescript": "^4.6.2"
+			}
+		},
+		"typescript": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+			"dev": true
+		}
+	}
+}

--- a/pkgs/global/package.json
+++ b/pkgs/global/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "kaboom-global",
 	"description": "Kaboom global type defs",
-	"version": "1.2.1",
+	"version": "2001.0.0-alpha.21",
 	"license": "MIT",
 	"homepage": "https://kaboomjs.com/",
 	"repository": "github:replit/kaboom",
@@ -12,8 +12,10 @@
 		"build": "node generate.js",
 		"prepare": "npm run build"
 	},
+	"peerDependencies": {
+		"kaboom": "2001.0.0-alpha.21"
+	},
 	"devDependencies": {
-		"kaboom": "file:../..",
 		"typescript": "^4.6.3"
 	}
 }

--- a/pkgs/global/package.json
+++ b/pkgs/global/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "kaboom-global",
+	"description": "Kaboom global type defs",
+	"version": "1.2.1",
+	"license": "MIT",
+	"homepage": "https://kaboomjs.com/",
+	"repository": "github:replit/kaboom",
+	"author": "tga <tga@space55.xyz>",
+	"type": "module",
+	"types": "./dist/kaboomGlobal.d.ts",
+	"scripts": {
+		"build": "node generate.js",
+		"prepare": "npm run build"
+	},
+	"devDependencies": {
+		"kaboom": "file:../..",
+		"typescript": "^4.6.3"
+	}
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -135,24 +135,12 @@ function buildTypes() {
 		}
 	})
 
-	// check if global defs are being generated
-	let globalGenerated = false
-
-	// window attribs to overwrite
-	const overwrites = new Set([
-		"origin",
-		"focus",
-	])
-
 	// contain the type data for doc gen
 	const types = {}
 	const sections = [{
 		name: "Start",
 		entries: [ "kaboom" ],
 	}]
-
-	// generate global decls for KaboomCtx members
-	dts += "\ndeclare global {\n"
 
 	for (const stmt of stmts) {
 
@@ -171,13 +159,6 @@ function buildTypes() {
 			for (const name in stmt.members) {
 
 				const mem = stmt.members[name]
-
-				if (overwrites.has(name)) {
-					dts += "\t// @ts-ignore\n"
-				}
-
-				dts += `\tconst ${name}: KaboomCtx["${name}"]\n`
-
 				const tags = mem[0].jsDoc?.tags ?? {}
 
 				if (tags["section"]) {
@@ -198,16 +179,8 @@ function buildTypes() {
 
 			}
 
-			globalGenerated = true
-
 		}
 
-	}
-
-	dts += "}\n"
-
-	if (!globalGenerated) {
-		throw new Error("KaboomCtx not found, failed to generate global defs.")
 	}
 
 	fs.writeFileSync("site/doc.json", JSON.stringify({


### PR DESCRIPTION
Currently kaboom always generate global type definitions, even when user is not using them by turning `global` option to `false`. Type defs for global variables should be optional too, or there'll be too much unused functions in global namespace

```js
const k = kaboom({
    global: false,
})

// tsc should catch this as error!
add()
```

This PR adds a separate package `kaboom-global` to contain the type defs for kaboom global functions, copies the code from `scripts/build.js` that generates global types to `pkgs/global/generate.js`

Currently this works by installing kaboom (the version of peer depended kaboom is synced with the version of `kaboom-global`) as peer dependency, then read `node_modules/kaboom/src/type.ts` to generate a `dist/kaboomGlobal.ts` which will be used as the typescript entry for the package

However this adds a little friction to users who want to use kaboom globals but also want types, that they have to `npm install kaboom-global`