### PR TITLE
Remove default debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - (**BREAK**) renamed `cursor()` to `setCursor()`
 - (**BREAK**) renamed `fullscreen()` to `setFullscreen()`
 - moved type defs for global functions to `import "kaboom/global"`
+- removed `debug` mode, manually bind keys to enter `debug.inspect` or use helper `bindDebugKeys()` to use the previous debug key layout
 
 ### v2000.2.6
 

--- a/demo/collision.js
+++ b/demo/collision.js
@@ -21,9 +21,6 @@ const player = add([
 	rotate(0),
 	// area() component gives the object a collider, which enables collision checking
 	area(),
-// 	area({ shape: new Polygon([vec2(0), vec2(100), vec2(-100, 100)]) }),
-	area({ shape: new Rect(vec2(0), 12, 120) }),
-// 	area({ scale: 0.5 }),
 	// body() component makes an object respond to physics
 	body(),
 ])

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3661,7 +3661,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		return game.ev.on("onTouchEnd", f)
 	}
 
-	function enterDebugMode() {
+	function bindDebugKeys() {
 
 		onKeyPress("f1", () => {
 			debug.inspect = !debug.inspect
@@ -3685,19 +3685,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 		onKeyPress("f10", () => {
 			debug.stepFrame()
-		})
-
-		onKeyPress("f5", () => {
-			game.ev.onOnce("frameEnd", () => download("kaboom.png", screenshot()))
-		})
-
-		onKeyPress("f6", () => {
-			if (debug.curRecording) {
-				debug.curRecording.download()
-				debug.curRecording = null
-			} else {
-				debug.curRecording = record()
-			}
 		})
 
 	}
@@ -5014,10 +5001,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 			game.scenes[id](...args)
 
-			if (gopt.debug !== false) {
-				enterDebugMode()
-			}
-
 			if (gopt.burp) {
 				enterBurpMode()
 			}
@@ -5769,10 +5752,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	}
 
-	if (gopt.debug !== false) {
-		enterDebugMode()
-	}
-
 	if (gopt.burp) {
 		enterBurpMode()
 	}
@@ -6005,9 +5984,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			}
 			checkFrame()
 			drawFrame()
-			if (gopt.debug !== false) {
-				drawDebug()
-			}
+			drawDebug()
 		}
 
 	})
@@ -6191,6 +6168,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		pushMatrix,
 		// debug
 		debug,
+		bindDebugKeys,
 		// scene
 		scene,
 		go,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1942,6 +1942,12 @@ export interface KaboomCtx {
 	 */
 	debug: Debug,
 	/**
+	 * Bind some default keys to certain debug actions. (F1 to toggle debug.inspect, F2 to clear debug log, F8 to toggle debug.paused, F7 to slow time, F9 to fast foward time, F10 to step to next frame)
+	 *
+	 * @since v20001.0
+	 */
+	bindDebugKeys: () => void,
+	/**
 	 * Import a plugin.
 	 *
 	 * @section Misc
@@ -2087,10 +2093,6 @@ export interface KaboomOpt {
 	 * When stretching if keep aspect ratio and leave black bars on remaining spaces. (note: not working properly at the moment.)
 	 */
 	letterbox?: boolean,
-	/**
-	 * If register debug buttons (default true)
-	 */
-	debug?: boolean,
 	/**
 	 * Default font (defaults to "apl386o", with "apl386", "sink", "sinko" as other built-in options).
 	 */


### PR DESCRIPTION
- There's been complaints about F5 being bound to take screenshot which disrupts browser default refresh behavior, yes it sucks and is a big oversight..
- Maybe "debug mode" should not be on by default, reduced that to a function call `bindDebugKeys()`