### PR TITLE
Level api rework (draft)

### DIFF
--- a/demo/camera.js
+++ b/demo/camera.js
@@ -14,32 +14,35 @@ const SPEED = 480
 gravity(2400)
 
 // Setup a basic level
-const level = addLevel([
-	"@  =  $",
-	"=======",
-], {
-	width: 64,
-	height: 64,
+const level = addLevel({
+	map: [
+		"@  =  $",
+		"=======",
+	],
+	tileWidth: 64,
+	tileHeight: 64,
 	pos: vec2(100, 200),
-	"@": () => [
-		sprite("bean"),
-		area(),
-		body(),
-		origin("bot"),
-		"player",
-	],
-	"=": () => [
-		sprite("grass"),
-		area(),
-		body({ isStatic: true }),
-		origin("bot"),
-	],
-	"$": () => [
-		sprite("coin"),
-		area(),
-		origin("bot"),
-		"coin",
-	],
+	tiles: {
+		"@": () => [
+			sprite("bean"),
+			area(),
+			body(),
+			origin("bot"),
+			"player",
+		],
+		"=": () => [
+			sprite("grass"),
+			area(),
+			body({ isStatic: true }),
+			origin("bot"),
+		],
+		"$": () => [
+			sprite("coin"),
+			area(),
+			origin("bot"),
+			"coin",
+		],
+	},
 })
 
 // Get the player object from tag

--- a/demo/level.js
+++ b/demo/level.js
@@ -15,42 +15,45 @@ const SPEED = 480
 
 gravity(2400)
 
-const level = addLevel([
-	// Design the level layout with symbols
-	"@  ^ $$",
-	"=======",
-], {
+const level = addLevel({
+	map: [
+		// Design the level layout with symbols
+		"@  ^ $$",
+		"=======",
+	],
 	// The size of each grid
-	width: 64,
-	height: 64,
+	tileWidth: 64,
+	tileHeight: 64,
 	// The position of the top left block
 	pos: vec2(100, 200),
 	// Define what each symbol means (in components)
-	"@": () => [
-		sprite("bean"),
-		area(),
-		body(),
-		origin("bot"),
-		"player",
-	],
-	"=": () => [
-		sprite("grass"),
-		area(),
-		body({ isStatic: true }),
-		origin("bot"),
-	],
-	"$": () => [
-		sprite("coin"),
-		area(),
-		origin("bot"),
-		"coin",
-	],
-	"^": () => [
-		sprite("spike"),
-		area(),
-		origin("bot"),
-		"danger",
-	],
+	tiles: {
+		"@": () => [
+			sprite("bean"),
+			area(),
+			body(),
+			origin("bot"),
+			"player",
+		],
+		"=": () => [
+			sprite("grass"),
+			area(),
+			body({ isStatic: true }),
+			origin("bot"),
+		],
+		"$": () => [
+			sprite("coin"),
+			area(),
+			origin("bot"),
+			"coin",
+		],
+		"^": () => [
+			sprite("spike"),
+			area(),
+			origin("bot"),
+			"danger",
+		],
+	},
 })
 
 // Get the player object from tag

--- a/demo/platformer.js
+++ b/demo/platformer.js
@@ -105,58 +105,60 @@ const LEVELS = [
 // define what each symbol means in the level graph
 const levelConf = {
 	// grid size
-	width: 64,
-	height: 64,
+	tileWidth: 64,
+	tileHeight: 64,
 	// define each object as a list of components
-	"=": () => [
-		sprite("grass"),
-		area(),
-		body({ isStatic: true }),
-		origin("bot"),
-	],
-	"$": () => [
-		sprite("coin"),
-		area(),
-		pos(0, -9),
-		origin("bot"),
-		"coin",
-	],
-	"%": () => [
-		sprite("prize"),
-		area(),
-		body({ isStatic: true }),
-		origin("bot"),
-		"prize",
-	],
-	"^": () => [
-		sprite("spike"),
-		area(),
-		body({ isStatic: true }),
-		origin("bot"),
-		"danger",
-	],
-	"#": () => [
-		sprite("apple"),
-		area(),
-		origin("bot"),
-		body(),
-		"apple",
-	],
-	">": () => [
-		sprite("ghosty"),
-		area(),
-		origin("bot"),
-		body(),
-		patrol(),
-		"enemy",
-	],
-	"@": () => [
-		sprite("portal"),
-		area({ scale: 0.5 }),
-		origin("bot"),
-		pos(0, -12),
-		"portal",
-	],
+	tiles: {
+		"=": () => [
+			sprite("grass"),
+			area(),
+			body({ isStatic: true }),
+			origin("bot"),
+		],
+		"$": () => [
+			sprite("coin"),
+			area(),
+			pos(0, -9),
+			origin("bot"),
+			"coin",
+		],
+		"%": () => [
+			sprite("prize"),
+			area(),
+			body({ isStatic: true }),
+			origin("bot"),
+			"prize",
+		],
+		"^": () => [
+			sprite("spike"),
+			area(),
+			body({ isStatic: true }),
+			origin("bot"),
+			"danger",
+		],
+		"#": () => [
+			sprite("apple"),
+			area(),
+			origin("bot"),
+			body(),
+			"apple",
+		],
+		">": () => [
+			sprite("ghosty"),
+			area(),
+			origin("bot"),
+			body(),
+			patrol(),
+			"enemy",
+		],
+		"@": () => [
+			sprite("portal"),
+			area({ scale: 0.5 }),
+			origin("bot"),
+			pos(0, -12),
+			"portal",
+		],
+	},
 }
 
 scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
@@ -164,7 +166,10 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
 	gravity(3200)
 
 	// add level to scene
-	const level = addLevel(LEVELS[levelId ?? 0], levelConf)
+	const level = addLevel({
+		map: LEVELS[levelId ?? 0],
+		...levelConf,
+	})
 
 	// define player object
 	const player = add([
@@ -234,7 +239,7 @@ scene("game", ({ levelId, coins } = { levelId: 0, coins: 0 }) => {
 	// grow an apple if player's head bumps into an obj with "prize" tag
 	player.onHeadbutt((obj) => {
 		if (obj.is("prize") && !hasApple) {
-			const apple = level.spawn("#", obj.gridPos.sub(0, 1))
+			const apple = level.spawn("#", obj.tilePos.sub(0, 1))
 			apple.jump()
 			hasApple = true
 			play("blip")

--- a/demo/rpg.js
+++ b/demo/rpg.js
@@ -27,7 +27,7 @@ scene("main", (levelIdx) => {
 	}
 
 	// level layouts
-	const levels = [
+	const maps = [
 		[
 			"=====|===",
 			"=       =",
@@ -52,41 +52,44 @@ scene("main", (levelIdx) => {
 		],
 	]
 
-	const level = addLevel(levels[levelIdx], {
-		width: 64,
-		height: 64,
+	const level = addLevel({
+		map: maps[levelIdx],
+		tileWidth: 64,
+		tileHeight: 64,
 		pos: vec2(64, 64),
-		"=": () => [
-			sprite("grass"),
-			area(),
-			body({ isStatic: true }),
-		],
-		"-": () => [
-			sprite("steel"),
-			area(),
-			body({ isStatic: true }),
-		],
-		"$": () => [
-			sprite("key"),
-			area(),
-			"key",
-		],
-		"@": () => [
-			sprite("bean"),
-			area(),
-			body(),
-			"player",
-		],
-		"|": () => [
-			sprite("door"),
-			area(),
-			body({ isStatic: true }),
-			"door",
-		],
-		// any() is a special function that gets called everytime there's a
+		tiles: {
+			"=": () => [
+				sprite("grass"),
+				area(),
+				body({ isStatic: true }),
+			],
+			"-": () => [
+				sprite("steel"),
+				area(),
+				body({ isStatic: true }),
+			],
+			"$": () => [
+				sprite("key"),
+				area(),
+				"key",
+			],
+			"@": () => [
+				sprite("bean"),
+				area(),
+				body(),
+				"player",
+			],
+			"|": () => [
+				sprite("door"),
+				area(),
+				body({ isStatic: true }),
+				"door",
+			],
+		},
+		// wildcardTile is a special function that gets called everytime there's a
 		// symbole not defined above and is supposed to return what that symbol
 		// means
-		any(ch) {
+		wildcardTile: (ch) => {
 			const char = characters[ch]
 			if (char) {
 				return [
@@ -155,7 +158,7 @@ scene("main", (levelIdx) => {
 
 	player.onCollide("door", () => {
 		if (hasKey) {
-			if (levelIdx + 1 < levels.length) {
+			if (levelIdx + 1 < maps.length) {
 				go("main", levelIdx + 1)
 			} else {
 				go("win")

--- a/demo/scenes.js
+++ b/demo/scenes.js
@@ -16,7 +16,7 @@ loadSound("portal", "/sounds/portal.mp3")
 const SPEED = 480
 
 // Design 2 levels
-const LEVELS = [
+const MAPS = [
 	[
 		"@  ^ $$ >",
 		"=========",
@@ -34,41 +34,44 @@ scene("game", ({ levelIdx, score }) => {
 	gravity(2400)
 
 	// Use the level passed, or first level
-	const level = addLevel(LEVELS[levelIdx || 0], {
-		width: 64,
-		height: 64,
+	const level = addLevel({
+		map: MAPS[levelIdx || 0],
+		tileWidth: 64,
+		tileHeight: 64,
 		pos: vec2(100, 200),
-		"@": () => [
-			sprite("bean"),
-			area(),
-			body(),
-			origin("bot"),
-			"player",
-		],
-		"=": () => [
-			sprite("grass"),
-			area(),
-			body({ isStatic: true }),
-			origin("bot"),
-		],
-		"$": () => [
-			sprite("coin"),
-			area(),
-			origin("bot"),
-			"coin",
-		],
-		"^": () => [
-			sprite("spike"),
-			area(),
-			origin("bot"),
-			"danger",
-		],
-		">": () => [
-			sprite("portal"),
-			area(),
-			origin("bot"),
-			"portal",
-		],
+		tiles: {
+			"@": () => [
+				sprite("bean"),
+				area(),
+				body(),
+				origin("bot"),
+				"player",
+			],
+			"=": () => [
+				sprite("grass"),
+				area(),
+				body({ isStatic: true }),
+				origin("bot"),
+			],
+			"$": () => [
+				sprite("coin"),
+				area(),
+				origin("bot"),
+				"coin",
+			],
+			"^": () => [
+				sprite("spike"),
+				area(),
+				origin("bot"),
+				"danger",
+			],
+			">": () => [
+				sprite("portal"),
+				area(),
+				origin("bot"),
+				"portal",
+			],
+		},
 	})
 
 	// Get the player object from tag
@@ -112,7 +115,7 @@ scene("game", ({ levelIdx, score }) => {
 	// Enter the next level on portal
 	player.onCollide("portal", () => {
 		play("portal")
-		if (levelIdx < LEVELS.length - 1) {
+		if (levelIdx < MAPS.length - 1) {
 			// If there's a next level, go() to the same scene but load the next level
 			go("game", {
 				levelIdx: levelIdx + 1,

--- a/demo/spriteatlas.js
+++ b/demo/spriteatlas.js
@@ -137,87 +137,93 @@ loadSpriteAtlas("/sprites/dungeon.png", {
 // loadSpriteAtlas("/sprites/dungeon.png", "/sprites/dungeon.json")
 
 // floor
-addLevel([
-	"xxxxxxxxxx",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-	"          ",
-], {
-	width: 16,
-	height: 16,
-	" ": () => [
-		sprite("floor", { frame: ~~rand(0, 8) }),
+addLevel({
+	map: [
+		"xxxxxxxxxx",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
+		"          ",
 	],
+	tileWidth: 16,
+	tileHeight: 16,
+	tiles: {
+		" ": () => [
+			sprite("floor", { frame: ~~rand(0, 8) }),
+		],
+	},
 })
 
 // objects
-const map = addLevel([
-	"tttttttttt",
-	"cwwwwwwwwd",
-	"l        r",
-	"l        r",
-	"l        r",
-	"l      $ r",
-	"l        r",
-	"l $      r",
-	"attttttttb",
-	"wwwwwwwwww",
-], {
-	width: 16,
-	height: 16,
-	"$": () => [
-		sprite("chest"),
-		area(),
-		body({ isStatic: true }),
-		{ opened: false },
-		"chest",
+const map = addLevel({
+	map: [
+		"tttttttttt",
+		"cwwwwwwwwd",
+		"l        r",
+		"l        r",
+		"l        r",
+		"l      $ r",
+		"l        r",
+		"l $      r",
+		"attttttttb",
+		"wwwwwwwwww",
 	],
-	"a": () => [
-		sprite("wall_botleft"),
-		area({ shape: new Rect(vec2(0), 4, 16) }),
-		body({ isStatic: true }),
-	],
-	"b": () => [
-		sprite("wall_botright"),
-		area({ shape: new Rect(vec2(12, 0), 4, 16) }),
-		body({ isStatic: true }),
-	],
-	"c": () => [
-		sprite("wall_topleft"),
-		area(),
-		body({ isStatic: true }),
-	],
-	"d": () => [
-		sprite("wall_topright"),
-		area(),
-		body({ isStatic: true }),
-	],
-	"w": () => [
-		sprite("wall"),
-		area(),
-		body({ isStatic: true }),
-	],
-	"t": () => [
-		sprite("wall_top"),
-		area({ shape: new Rect(vec2(0, 12), 16, 4) }),
-		body({ isStatic: true }),
-	],
-	"l": () => [
-		sprite("wall_left"),
-		area({ shape: new Rect(vec2(0), 4, 16) }),
-		body({ isStatic: true }),
-	],
-	"r": () => [
-		sprite("wall_right"),
-		area({ shape: new Rect(vec2(12, 0), 4, 16) }),
-		body({ isStatic: true }),
-	],
+	tileWidth: 16,
+	tileHeight: 16,
+	tiles: {
+		"$": () => [
+			sprite("chest"),
+			area(),
+			body({ isStatic: true }),
+			{ opened: false },
+			"chest",
+		],
+		"a": () => [
+			sprite("wall_botleft"),
+			area({ shape: new Rect(vec2(0), 4, 16) }),
+			body({ isStatic: true }),
+		],
+		"b": () => [
+			sprite("wall_botright"),
+			area({ shape: new Rect(vec2(12, 0), 4, 16) }),
+			body({ isStatic: true }),
+		],
+		"c": () => [
+			sprite("wall_topleft"),
+			area(),
+			body({ isStatic: true }),
+		],
+		"d": () => [
+			sprite("wall_topright"),
+			area(),
+			body({ isStatic: true }),
+		],
+		"w": () => [
+			sprite("wall"),
+			area(),
+			body({ isStatic: true }),
+		],
+		"t": () => [
+			sprite("wall_top"),
+			area({ shape: new Rect(vec2(0, 12), 16, 4) }),
+			body({ isStatic: true }),
+		],
+		"l": () => [
+			sprite("wall_left"),
+			area({ shape: new Rect(vec2(0), 4, 16) }),
+			body({ isStatic: true }),
+		],
+		"r": () => [
+			sprite("wall_right"),
+			area({ shape: new Rect(vec2(12, 0), 4, 16) }),
+			body({ isStatic: true }),
+		],
+	},
 })
 
 const player = add([

--- a/src/types.ts
+++ b/src/types.ts
@@ -1650,7 +1650,7 @@ export interface KaboomCtx {
 	 * })
 	 * ```
 	 */
-	addLevel(map: string[], options: LevelOpt): GameObj,
+	addLevel(data: LevelData): GameObj,
 	/**
 	 * Get data from local storage, if not present can set to a default value.
 	 *
@@ -4282,15 +4282,19 @@ export interface StateComp extends Comp {
 	onStateDraw: (state: string, action: () => void) => EventCanceller,
 }
 
-export interface LevelOpt {
+export interface LevelData {
 	/**
-	 * Width of each block.
+	 * The level data as ascii drawing.
 	 */
-	width: number,
+	map: string[],
 	/**
-	 * Height of each block.
+	 * Width of each tile.
 	 */
-	height: number,
+	tileWidth: number,
+	/**
+	 * Height of each tile.
+	 */
+	tileHeight: number,
 	/**
 	 * Position of the first block.
 	 */
@@ -4298,14 +4302,18 @@ export interface LevelOpt {
 	/**
 	 * Called when encountered an undefined symbol.
 	 */
-	any?: (s: string, pos: Vec2) => CompList<any> | undefined,
-	// TODO: should return CompList<any>
-	[sym: string]: any,
+	wildcardTile?: (sym: string, pos: Vec2) => CompList<any> | undefined,
+	/**
+	 * Definition of each tile.
+	 */
+	tiles: {
+		[sym: string]: (pos: Vec2) => CompList<any>,
+	},
 }
 
 export interface LevelComp extends Comp {
-	gridWidth(): number,
-	gridHeight(): number,
+	tileWidth(): number,
+	tileHeight(): number,
 	getPos(p: Vec2): Vec2,
 	getPos(x: number, y: number): Vec2,
 	spawn(sym: string, p: Vec2): GameObj,


### PR DESCRIPTION
Changes the `addLevel()` api, put all level related data into 1 single structure `LevelData`

- Put everything into one data struct, move level ascii drawing into `map` field
- More explicitly named fields
  - `width` -> `tileWidth`
  - `height` -> `tileHeight`
  - `any` -> `wildcardTile`
- Moved definition for each tile into one `tiles` map, to separate arbitrary fields and named fields

Previous: 

```js
const level = addLevel([
	"@  =  $",
	"=======",
], {
	width: 64,
	height: 64,
	pos: vec2(100, 200),
	"@": () => [
		sprite("bean"),
		area(),
		body(),
		origin("bot"),
		"player",
	],
	"=": () => [
		sprite("grass"),
		area(),
		body({ isStatic: true }),
		origin("bot"),
	],
	"$": () => [
		sprite("coin"),
		area(),
		origin("bot"),
		"coin",
	],
	any: (sym) => {
		const char = characters[sym]
		if (char) {
			return [
				sprite(char.sprite),
				"character",
				{ msg: char.msg },
			]
		}
	}
})
```

Now:
```js
const level = addLevel({
	map: [
		"@  =  $",
		"=======",
	],
	tileWidth: 64,
	tileHeight: 64,
	pos: vec2(100, 200),
	tiles: {
		"@": () => [
			sprite("bean"),
			area(),
			body(),
			origin("bot"),
			"player",
		],
		"=": () => [
			sprite("grass"),
			area(),
			body({ isStatic: true }),
			origin("bot"),
		],
		"$": () => [
			sprite("coin"),
			area(),
			origin("bot"),
			"coin",
		],
	},
	wildcardTile: (sym) => {
		const char = characters[sym]
		if (char) {
			return [
				sprite(char.sprite),
				"character",
				{ msg: char.msg },
			]
		}
	},
})
```