### PR TITLE
added BodyComp#multiJump() to do multiple jumps easy

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4598,6 +4598,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		let curPlatform: GameObj | null = null
 		let lastPlatformPos = null
 		let canDouble = true
+		let jumpsEffected = 0
 		let wantFall = false
 		const cleanups: Array<() => void> = []
 
@@ -4652,6 +4653,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 								wantFall = false
 							} else {
 								canDouble = true
+								jumpsEffected = 0
 								this.trigger("ground", curPlatform)
 							}
 						} else if (col.isTop() && this.isRising()) {
@@ -4746,6 +4748,20 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				}
 			},
 
+			multiJump(n: number, force: number) {
+				if (this.isGrounded()) {
+					this.jump(force)
+					jumpsEffected++
+				} else if (jumpsEffected < n) {
+					this.jump(force)
+					jumpsEffected++
+					this.trigger("multiJump")
+				}
+				else {
+					jumpsEffected = 0
+				}
+			},
+
 			onGround(action: () => void): EventCanceller {
 				return this.on("ground", action)
 			},
@@ -4766,6 +4782,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				return this.on("doubleJump", action)
 			},
 
+			onMultiJump(action: () => void): EventCanceller {
+				return this.on("multiJump", action)
+			}
 		}
 
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4105,6 +4105,10 @@ export interface BodyComp extends Comp {
 	 */
 	doubleJump(f?: number): void,
 	/**
+	 * Performs multiple jump (the initial jump only happens if player is grounded).
+	 */
+	multiJump(n: number, f?: number): void,
+	/**
 	 * Register an event that runs when a collision is resolved.
 	 *
 	 * @since v2001.0
@@ -4140,6 +4144,13 @@ export interface BodyComp extends Comp {
 	 * @since v2000.1
 	 */
 	onDoubleJump(action: () => void): EventCanceller,
+
+	/**
+	 * Register an event that runs when the object performs the non-first jump when multiple jumping.
+	 *
+	 * @since v2001.0
+	 */
+	onMultiJump(action: () => void): EventCanceller,
 }
 
 export interface BodyCompOpt {


### PR DESCRIPTION
I think it's great that you can do multiple jumps in an easy way, but also if someone needs to do it manually, they can always use jump. 

Also added `Body#onMultiJump()` and `on("multiJump")` events.