### PR TITLE
Fix hover events

### DIFF
--- a/demo/hover.js
+++ b/demo/hover.js
@@ -49,10 +49,10 @@ redBean.onHoverEnd(() => {
 blueBean.onHoverUpdate(() => {
 	const t = time() * 10
 	blueBean.color = rgb(
-			wave(0, 255, t),
-			wave(0, 255, t + 2),
-			wave(0, 255, t + 4),
-		)
+		wave(0, 255, t),
+		wave(0, 255, t + 2),
+		wave(0, 255, t + 4),
+	)
 
 	debug.log("blue bean on hover")
 })

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3517,6 +3517,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			return onMousePress(tag)
 		} else {
 			return forAllCurrentAndFuture(tag, (obj) => {
+				if (!obj.area)
+					throw new Error("onClick() requires the object to have area() component")
 				obj.onClick(() => action(obj))
 			})
 		}
@@ -3538,6 +3540,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	// add an event that runs once when objs with tag t is hovered
 	function onHover(t: Tag, action: (obj: GameObj) => void): EventCanceller {
 		return forAllCurrentAndFuture(t, (obj) => {
+			if (!obj.area)
+				throw new Error("onHover() requires the object to have area() component")
 			obj.onHover(() => action(obj))
 		})
 	}
@@ -3545,6 +3549,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	// add an event that runs once when objs with tag t is hovered
 	function onHoverUpdate(t: Tag, action: (obj: GameObj) => void): EventCanceller {
 		return forAllCurrentAndFuture(t, (obj) => {
+			if (!obj.area)
+				throw new Error("onHoverUpdate() requires the object to have area() component")
 			obj.onHoverUpdate(() => action(obj))
 		})
 	}
@@ -3552,6 +3558,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	// add an event that runs once when objs with tag t is unhovered
 	function onHoverEnd(t: Tag, action: (obj: GameObj) => void): EventCanceller {
 		return forAllCurrentAndFuture(t, (obj) => {
+			if (!obj.area)
+				throw new Error("onHoverEnd() requires the object to have area() component")
 			obj.onHoverEnd(() => action(obj))
 		})
 	}

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3215,9 +3215,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				})()
 				obj.parent = this
 				obj.transform = calcTransform(obj)
-				obj.trigger("add", this)
-				onLoad(() => obj.trigger("load"))
 				this.children.push(obj)
+				obj.trigger("add", this)
+				game.ev.trigger("add", this)
+				onLoad(() => obj.trigger("load"))
 				return obj
 			},
 
@@ -3497,6 +3498,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 	}
 
+	function onAdd(action: (obj: GameObj) => void) {
+		return game.ev.on("add", action)
+	}
+
 	// add an event that runs with objs with t1 collides with objs with t2
 	function onCollide(
 		t1: Tag,
@@ -3507,60 +3512,47 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	// add an event that runs when objs with tag t is clicked
-	function onClick(tag: Tag | (() => void), cb?: (obj: GameObj) => void): EventCanceller {
+	function onClick(tag: Tag | (() => void), action?: (obj: GameObj) => void): EventCanceller {
 		if (typeof tag === "function") {
 			return onMousePress(tag)
 		} else {
-			return onUpdate(tag, (o: GameObj) => {
-				if (!o.area) throw new Error("onClick() requires the object to have area() component")
-				if (o.isClicked()) {
-					cb(o)
-				}
+			return forAllCurrentAndFuture(tag, (obj) => {
+				obj.onClick(() => action(obj))
 			})
 		}
 	}
 
-	// add an event that runs once when objs with tag t is hovered
-	function onHover(t: string, action: (obj: GameObj) => void): EventCanceller {
-		return onUpdate(t, (o: GameObj) => {
-			if (!o.area) throw new Error("onHover() requires the object to have area() component")
-			
-			if (o.isHovering()) {
-				if (o.hoverStarted) return
-				o.hoverStarted = true
-				o.hoverEnded = false
-
-				action(o)
+	function forAllCurrentAndFuture(t: Tag, action: (obj: GameObj) => void): EventCanceller {
+		const a = get(t).forEach(action)
+		const b = onAdd((obj) => {
+			if (obj.is(t)) {
+				action(obj)
 			}
+		})
+		return () => {
+			a()
+			b()
+		}
+	}
+
+	// add an event that runs once when objs with tag t is hovered
+	function onHover(t: Tag, action: (obj: GameObj) => void): EventCanceller {
+		return forAllCurrentAndFuture(t, (obj) => {
+			obj.onHover(() => action(obj))
 		})
 	}
 
 	// add an event that runs once when objs with tag t is hovered
-	function onHoverUpdate(t: string, onHover: (obj: GameObj) => void, onNotHover?: (obj: GameObj) => void): EventCanceller {
-		return onUpdate(t, (o: GameObj) => {
-			if (!o.area) throw new Error("onHover() requires the object to have area() component")
-			if (o.isHovering()) {
-				onHover(o)
-			} else {
-				if (onNotHover) {
-					onNotHover(o)
-				}
-			}
+	function onHoverUpdate(t: Tag, action: (obj: GameObj) => void): EventCanceller {
+		return forAllCurrentAndFuture(t, (obj) => {
+			obj.onHoverUpdate(() => action(obj))
 		})
 	}
-	
+
 	// add an event that runs once when objs with tag t is unhovered
-	function onHoverEnd(t: string, action: (obj: GameObj) => void): EventCanceller {
-		return onUpdate(t, (o: GameObj) => {
-			if (!o.area) throw new Error("onHoverExit() requires the object to have area() component")
-			
-			if (!o.isHovering()) {
-				if (o.hoverEnded || !o.hoverStarted) return
-				o.hoverEnded = true
-				o.hoverStarted = false
-
-				action(o)
-			}
+	function onHoverEnd(t: Tag, action: (obj: GameObj) => void): EventCanceller {
+		return forAllCurrentAndFuture(t, (obj) => {
+			obj.onHoverEnd(() => action(obj))
 		})
 	}
 
@@ -4091,9 +4083,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				if (this === other || !other.area || !other.exists()) {
 					return null
 				}
-// 				if (this.colliding[other.id]) {
-// 					return this.colliding[other.id]
-// 				}
+				// if (this.colliding[other.id]) {
+					// return this.colliding[other.id]
+				// }
 				const a1 = this.worldArea()
 				const a2 = other.worldArea()
 				return sat(a1, a2)
@@ -4117,12 +4109,15 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			onHover(action: () => void): EventCanceller {
+				let hovering = false
 				return this.onUpdate(() => {
-					if(this.isHovering()) {
-						if (this.hoverStarted) return
-						this.hoverStarted = true
-						this.hoverEnded = false
-						action()
+					if (!hovering) {
+						if (this.isHovering()) {
+							hovering = true
+							action()
+						}
+					} else {
+						hovering = this.isHovering()
 					}
 				})
 			},
@@ -4140,12 +4135,15 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			onHoverEnd(action: () => void): EventCanceller {
+				let hovering = false
 				return this.onUpdate(() => {
-					if(!this.isHovering()) {
-						if (this.hoverEnded || !this.hoverStarted) return
-						this.hoverEnded = true
-						this.hoverStarted = false
-						action()
+					if (hovering) {
+						if (!this.isHovering()) {
+							hovering = false
+							action()
+						}
+					} else {
+						hovering = this.isHovering()
 					}
 				})
 			},
@@ -4245,7 +4243,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	}
 
-	// make the list of common render properties from the "pos", "scale", "color", "opacity", "rotate", "origin", "outline", and "shader" components of a character
+	// make the list of common render properties from the "pos", "scale", "color", "opacity", "rotate", "origin", "outline", and "shader" components of a game object
 	function getRenderProps(obj: GameObj<any>) {
 		return {
 			color: obj.color,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3997,8 +3997,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			id: "area",
 			colliding: {},
 			collisionIgnore: opt.collisionIgnore ?? [],
-			hoverStarted: false,
-			hoverEnded: false,
 
 			add() {
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3646,7 +3646,7 @@ export interface AreaComp extends Comp {
 	/**
 	 * If this object has ended its hover.
 	 */
-	 hoverEnded: boolean;
+	hoverEnded: boolean;
 	/**
 	 * If was just clicked on last frame.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -3640,14 +3640,6 @@ export interface AreaComp extends Comp {
 	 */
 	colliding: Record<GameObjID, Collision>,
 	/**
-	 * If this object has started its hover.
-	 */
-	hoverStarted: boolean;
-	/**
-	 * If this object has ended its hover.
-	 */
-	hoverEnded: boolean;
-	/**
 	 * If was just clicked on last frame.
 	 */
 	isClicked(): boolean,


### PR DESCRIPTION
- Use closed variable in `Area#onHover()` and `Area#onHoverEnd()` instead of states
- Used another approach for global `onHover()` etc events to reduce all future custom logic for these global event handlers, see new helper `forAllCurrentAndFuture()`