### PR TITLE
Part 1 - Refactor Kaboom classes

### DIFF
--- a/src/classes/Asset.ts
+++ b/src/classes/Asset.ts
@@ -1,0 +1,53 @@
+import { Event } from "../utils"
+
+export class Asset<D> {
+	done: boolean = false
+	data: D | null = null
+	error: Error | null = null
+	private onLoadEvents: Event<[D]> = new Event()
+	private onErrorEvents: Event<[Error]> = new Event()
+	private onFinishEvents: Event<[]> = new Event()
+	constructor(loader: Promise<D>) {
+		loader.then((data) => {
+			this.data = data
+			this.onLoadEvents.trigger(data)
+		}).catch((err) => {
+			this.error = err
+			if (this.onErrorEvents.numListeners() > 0) {
+				this.onErrorEvents.trigger(err)
+			} else {
+				throw err
+			}
+		}).finally(() => {
+			this.onFinishEvents.trigger()
+			this.done = true
+		})
+	}
+	static loaded<D>(data: D): Asset<D> {
+		const asset = new Asset(Promise.resolve(data))
+		asset.data = data
+		asset.done = true
+		return asset
+	}
+	onLoad(action: (data: D) => void) {
+		this.onLoadEvents.add(action)
+		return this
+	}
+	onError(action: (err: Error) => void) {
+		this.onErrorEvents.add(action)
+		return this
+	}
+	onFinish(action: () => void) {
+		this.onFinishEvents.add(action)
+		return this
+	}
+	then(action: (data: D) => void): Asset<D> {
+		return this.onLoad(action)
+	}
+	catch(action: (err: Error) => void): Asset<D> {
+		return this.onError(action)
+	}
+	finally(action: () => void): Asset<D> {
+		return this.onFinish(action)
+	}
+}

--- a/src/classes/AssetBucket.ts
+++ b/src/classes/AssetBucket.ts
@@ -1,0 +1,33 @@
+import { Asset } from "./Asset"
+
+export class AssetBucket<D> {
+	assets: Map<string, Asset<D>> = new Map()
+	lastUID: number = 0
+	add(name: string | null, loader: Promise<D>): Asset<D> {
+        // if user don't provide a name we use a generated one
+		const id = name ?? (this.lastUID++ + "")
+		const asset = new Asset(loader)
+		this.assets.set(id, asset)
+		return asset
+	}
+	addLoaded(name: string | null, data: D) {
+		const id = name ?? (this.lastUID++ + "")
+		const asset = Asset.loaded(data)
+		this.assets.set(id, asset)
+	}
+	get(handle: string): Asset<D> | void {
+		return this.assets.get(handle)
+	}
+	progress(): number {
+		if (this.assets.size === 0) {
+			return 1
+		}
+		let loaded = 0
+		this.assets.forEach((asset) => {
+			if (asset.done) {
+				loaded++
+			}
+		})
+		return loaded / this.assets.size
+	}
+}

--- a/src/classes/Collision.ts
+++ b/src/classes/Collision.ts
@@ -1,0 +1,37 @@
+import { GameObj, Vec2 } from "../types"
+
+export class Collision {
+	source: GameObj
+	target: GameObj
+	displacement: Vec2
+	resolved: boolean = false
+	constructor(source: GameObj, target: GameObj, dis: Vec2, resolved = false) {
+		this.source = source
+		this.target = target
+		this.displacement = dis
+		this.resolved = resolved
+	}
+	reverse() {
+		return new Collision(
+			this.target,
+			this.source,
+			this.displacement.scale(-1),
+			this.resolved,
+		)
+	}
+	isLeft() {
+		return this.displacement.x > 0
+	}
+	isRight() {
+		return this.displacement.x < 0
+	}
+	isTop() {
+		return this.displacement.y > 0
+	}
+	isBottom() {
+		return this.displacement.y < 0
+	}
+	preventResolve() {
+		this.resolved = true
+	}
+}

--- a/src/classes/SoundData.ts
+++ b/src/classes/SoundData.ts
@@ -1,0 +1,28 @@
+
+
+import { isDataURL, dataURLToArrayBuffer } from "../utils"
+import type { AudioData } from "../types"
+
+export class SoundData {
+
+	buf: AudioBuffer
+
+	constructor(buf: AudioBuffer) {
+		this.buf = buf
+	}
+
+	static fromArrayBuffer(buf: ArrayBuffer, audio: AudioData): Promise<SoundData> {
+		return new Promise((resolve, reject) =>
+			audio.ctx.decodeAudioData(buf, resolve, reject),
+		).then((buf: AudioBuffer) => new SoundData(buf))
+	}
+
+	static fromURL(url: string, audio: AudioData, fetchArrayBuffer): Promise<SoundData> {
+		if (isDataURL(url)) {
+			return SoundData.fromArrayBuffer(dataURLToArrayBuffer(url), audio)
+		} else {
+			return fetchArrayBuffer(url).then((buf) => SoundData.fromArrayBuffer(buf, audio))
+		}
+	}
+
+}

--- a/src/classes/SpriteData.ts
+++ b/src/classes/SpriteData.ts
@@ -1,0 +1,36 @@
+import { Quad } from "../math"
+import { Texture } from "./Texture"
+import type { SpriteAnims, LoadSpriteSrc, LoadSpriteOpt, KaboomOpt } from "../types"
+
+export class SpriteData {
+
+	tex: Texture
+	frames: Quad[] = [new Quad(0, 0, 1, 1)]
+	anims: SpriteAnims = {}
+
+	constructor(tex: Texture, frames?: Quad[], anims: SpriteAnims = {}) {
+		this.tex = tex
+		if (frames) this.frames = frames
+		this.anims = anims
+	}
+
+	static from(src: LoadSpriteSrc, loadImg, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, slice, opt: LoadSpriteOpt = {}): Promise<SpriteData> {
+		return typeof src === "string"
+			? SpriteData.fromURL(src, loadImg, gl, gc, gopt, slice, opt)
+			: Promise.resolve(SpriteData.fromImage(src, gl, gc, gopt, slice, opt),
+			)
+	}
+
+	static fromImage(data: TexImageSource, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, slice, opt: LoadSpriteOpt = {}): SpriteData {
+		return new SpriteData(
+			Texture.fromImage(data, gl, gc, gopt, opt),
+			slice(opt.sliceX || 1, opt.sliceY || 1),
+			opt.anims ?? {},
+		)
+	}
+
+	static fromURL(url: string, loadImg, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, slice, opt: LoadSpriteOpt = {}): Promise<SpriteData> {
+		return loadImg(url).then((img) => SpriteData.fromImage(img, gl, gc, gopt, slice, opt))
+	}
+
+}

--- a/src/classes/Texture.ts
+++ b/src/classes/Texture.ts
@@ -1,0 +1,88 @@
+import { KaboomOpt, TextureOpt } from "../types"
+
+export class Texture {
+	gl: WebGLRenderingContext
+	gc: (() => void)[]
+	gopt: KaboomOpt
+
+	glTex: WebGLTexture
+	width: number
+	height: number
+
+	constructor(w: number, h: number, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, opt: TextureOpt = {}) {
+		this.gl = gl
+		this.gc = gc
+		this.gopt = gopt
+
+		this.glTex = gl.createTexture()
+		gc.push(() => this.free())
+		this.bind()
+
+		if (w && h) {
+			gl.texImage2D(
+				gl.TEXTURE_2D,
+				0, gl.RGBA,
+				w,
+				h,
+				0,
+				gl.RGBA,
+				gl.UNSIGNED_BYTE,
+				null,
+			)
+		}
+
+		this.width = w
+		this.height = h
+
+		const filter = (() => {
+			switch (opt.filter ?? gopt.texFilter) {
+				case "linear": return gl.LINEAR
+				case "nearest": return gl.NEAREST
+				default: return gl.NEAREST
+			}
+		})()
+
+		const wrap = (() => {
+			switch (opt.wrap) {
+				case "repeat": return gl.REPEAT
+				case "clampToEdge": return gl.CLAMP_TO_EDGE
+				default: return gl.CLAMP_TO_EDGE
+			}
+		})()
+
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter)
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter)
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrap)
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap)
+		this.unbind()
+
+	}
+
+	static fromImage(img: TexImageSource, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, opt: TextureOpt = {}): Texture {
+		const tex = new Texture(0, 0, gl, gc, gopt, opt)
+		tex.bind()
+		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img)
+		tex.width = img.width
+		tex.height = img.height
+		tex.unbind()
+		return tex
+	}
+
+	update(x: number, y: number, img: TexImageSource) {
+		this.bind()
+		this.gl.texSubImage2D(this.gl.TEXTURE_2D, 0, x, y, this.gl.RGBA, this.gl.UNSIGNED_BYTE, img)
+		this.unbind()
+	}
+
+	bind() {
+		this.gl.bindTexture(this.gl.TEXTURE_2D, this.glTex)
+	}
+
+	unbind() {
+		this.gl.bindTexture(this.gl.TEXTURE_2D, null)
+	}
+
+	free() {
+		this.gl.deleteTexture(this.glTex)
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -464,7 +464,7 @@ export interface KaboomCtx {
 	 *     player.hurt(1)
 	 *     bad.hurt(1)
 	 * })
-     *
+	 *
 	 * player.onCollide("apple", () => {
 	 *     player.heal(1)
 	 * })
@@ -2567,15 +2567,21 @@ export declare class SpriteData {
 	frames: Quad[]
 	anims: SpriteAnims
 	constructor(tex: Texture, frames?: Quad[], anims?: SpriteAnims)
-	static fromImage(data: TexImageSource, opt?: LoadSpriteOpt): SpriteData
-	static fromURL(url: string, opt?: LoadSpriteOpt): Promise<SpriteData>
+	static fromImage(data: TexImageSource, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, slice: any, opt?: LoadSpriteOpt): SpriteData
+	static fromURL(url: string, loadImg, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, slice, opt?: LoadSpriteOpt): Promise<SpriteData>
+}
+
+export type AudioData = {
+    ctx: AudioContext;
+    masterNode: GainNode;
+    burpSnd: SoundData;
 }
 
 export declare class SoundData {
 	buf: AudioBuffer
 	constructor(buf: AudioBuffer)
-	static fromArrayBuffer(buf: ArrayBuffer): Promise<SoundData>
-	static fromURL(url: string): Promise<SoundData>
+	static fromArrayBuffer(buf: ArrayBuffer, audio: AudioData): Promise<SoundData>
+	static fromURL(url: string, audio: AudioData, fetchArrayBuffer): Promise<SoundData>
 }
 
 export interface LoadBitmapFontOpt {
@@ -2704,11 +2710,14 @@ export type TextureOpt = {
 }
 
 export declare class Texture {
+	gl: WebGLRenderingContext
+	gc: (() => void)[]
+	gopt: KaboomOpt
 	glTex: WebGLTexture
 	width: number
 	height: number
-	constructor(w: number, h: number, opt?: TextureOpt)
-	static fromImage(img: TexImageSource, opt?: TextureOpt): Texture
+	constructor(w: number, h: number, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, opt?: TextureOpt)
+	static fromImage(img: TexImageSource, gl: WebGLRenderingContext, gc: (() => void)[], gopt: KaboomOpt, opt?: TextureOpt): Texture
 	update(x: number, y: number, img: TexImageSource)
 	bind()
 	unbind()


### PR DESCRIPTION
This is a refactor for moving Classes outside of the main kaboom function

These classes will need to be referenced by functions outside of `kaboom.ts`

This is needed to eventually create a headless mode to be run server side. IE referenced from `kaboomCore.ts`


