### PR TITLE
Fixed mousePos() and onClick() to also work on Firefox

### DIFF
--- a/examples/onClick.js
+++ b/examples/onClick.js
@@ -1,0 +1,12 @@
+kaboom()
+
+loadSprite("bean", "/sprites/bean.png")
+const player = add([sprite("bean"), area(), pos(center()), "player"])
+
+player.onClick(() => {
+  debug.log("clicked!")
+})
+
+onClick("player", () => {
+  debug.log("clicked!")
+})

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2968,7 +2968,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	canvasEvents.mousemove = (e) => {
 		game.ev.onOnce("input", () => {
-			setMousePos(e.offsetX, e.offsetY)
+			setMousePos(e.x, e.y)
 			game.ev.trigger("mouseMove")
 		})
 	}


### PR DESCRIPTION
In kaboom@3000.0.0-alpha.14 `mousePos()` and by extension `onClick()` where broken on Firefox. The reason turned out that `e.offsetX` and `e.offsetY` on firefox are always 0. This PR swaps the use of `e.offsetX` and `e.offsetY` with `e.x` and `e.y`. 

This fix works both on Firefox while maintaning functionality on chromium based browsers.

Created a test in `onClick.js` to make sure everything works all right.