### PR TITLE
Improve gamepad support

### DIFF
--- a/src/gamepad.json
+++ b/src/gamepad.json
@@ -45,6 +45,38 @@
 			"right": { "x": 2, "y": 3 }
 		}
 	},
+	"Joy-Con (L) (STANDARD GAMEPAD Vendor: 057e Product: 2006)": {
+		"buttons": {
+			"0": "south",
+			"1": "east",
+			"2": "west",
+			"3": "north",
+			"4": "lshoulder",
+			"5": "rshoulder",
+			"9": "select",
+			"10": "lstick",
+			"16": "start"
+		},
+		"sticks": {
+			"left": { "x": 0, "y": 1 }
+		}
+	},
+	"Joy-Con (R) (STANDARD GAMEPAD Vendor: 057e Product: 2007)": {
+		"buttons": {
+			"0": "south",
+			"1": "east",
+			"2": "west",
+			"3": "north",
+			"4": "lshoulder",
+			"5": "rshoulder",
+			"9": "start",
+			"10": "lstick",
+			"16": "select"
+		},
+		"sticks": {
+			"left": { "x": 0, "y": 1 }
+		}
+	},
 	"Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)": {
 		"buttons": {
 			"0": "south",

--- a/src/gamepad.json
+++ b/src/gamepad.json
@@ -23,24 +23,26 @@
 		"buttons": {
 			"0": "south",
 			"1": "east",
-			"2": "north",
-			"3": "west",
-			"4": "ltrigger",
-			"5": "rtrigger",
-			"6": "lshoulder",
-			"7": "rshoulder",
+			"2": "west",
+			"3": "north",
+			"4": "lshoulder",
+			"5": "rshoulder",
+			"6": "ltrigger",
+			"7": "rtrigger",
 			"8": "select",
 			"9": "start",
 			"10": "lstick",
 			"11": "rstick",
-			"12": "dpad-south",
-			"13": "dpad-east",
-			"14": "dpad-north",
-			"15": "dpad-west"
+			"12": "dpad-north",
+			"13": "dpad-south",
+			"14": "dpad-west",
+			"15": "dpad-east",
+			"16": "home",
+			"17": "capture"
 		},
 		"sticks": {
 			"left": { "x": 0, "y": 1 },
-			"right": { "x": 2, "y": 5 }
+			"right": { "x": 2, "y": 3 }
 		}
 	},
 	"Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)": {

--- a/src/gamepad.json
+++ b/src/gamepad.json
@@ -43,6 +43,32 @@
 			"right": { "x": 2, "y": 5 }
 		}
 	},
+	"Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)": {
+		"buttons": {
+			"0": "south",
+			"1": "east",
+			"2": "west",
+			"3": "north",
+			"4": "lshoulder",
+			"5": "rshoulder",
+			"6": "ltrigger",
+			"7": "rtrigger",
+			"8": "select",
+			"9": "start",
+			"10": "lstick",
+			"11": "rstick",
+			"12": "dpad-north",
+			"13": "dpad-south",
+			"14": "dpad-west",
+			"15": "dpad-east",
+			"16": "home",
+			"17": "capture"
+		},
+		"sticks": {
+			"left": { "x": 0, "y": 1 },
+			"right": { "x": 2, "y": 3 }
+		}
+	},
 	"default": {
 		"buttons": {
 			"0": "north",

--- a/src/types.ts
+++ b/src/types.ts
@@ -2311,6 +2311,8 @@ export type GamepadButton =
 	| "dpad-east"
 	| "dpad-south"
 	| "dpad-west"
+	| "home"
+	| "capture"
 
 /**
  * Inspect info for a character.


### PR DESCRIPTION
This PR adds support for using Nintendo's Joy-Con's individually (only the left one or only the right one) as well as for their Pro Controller. It also fixes the mapping for some buttons when using both L+R as a single controller.

I also added two new possible values for the `GamepadButton` type to allow users to use the `home` and `capture` buttons in their games. This is something that we might wanna rename to standardise across vendors (I know Sony also has a `home` button and they added one to `share` in their PS4 controller but this one would probably be mapped to `select`).

----

I would also like to allow users to pass on their custom gamepad definitions via `KaboomOpt`. This would allow them to extend `GAMEPAD_MAP` locally or even overwrite core mappings in case this is something they need for their games (eg. the current mapping for individual Joy-Con's assumes users will use the controller in landscape and doesn't map the shoulder and trigger buttons at all).

Something like this should do:

https://github.com/replit/kaboom/blob/c4ec07af8f6d9969f1b526ba642c63dae6ca4acd/src/kaboom.ts#L6470

```js
 const map = gopt.GAMEPAD_MAP[gamepad.id] ?? GAMEPAD_MAP[gamepad.id] ?? GAMEPAD_MAP["default"] 
```

Adding support for using the controller's built-in rumble motors would also be neat: https://developer.mozilla.org/en-US/docs/Web/API/GamepadHapticActuator/playEffect

But these changes belong in a different PR for now.