### PR TITLE
Kaboom gamepads

### DIFF
--- a/examples/multigamepad.js
+++ b/examples/multigamepad.js
@@ -1,0 +1,54 @@
+kaboom()
+setGravity(2400)
+setBackground(0, 0, 0)
+loadSprite("bean", "/sprites/bean.png")
+
+const playerColors = [
+	rgb(252, 53, 43),
+	rgb(0, 255, 0),
+	rgb(43, 71, 252),
+	rgb(255, 255, 0),
+	rgb(255, 0, 255),
+]
+
+let playerCount = 0
+
+function addPlayer(gamepad) {
+	const player = add([
+		pos(center()),
+		anchor("center"),
+		sprite("bean"),
+		color(playerColors[playerCount]),
+		area(),
+		body(),
+		doubleJump(),
+	])
+
+	playerCount++
+
+	onUpdate(() => {
+		const leftStick = gamepad.getStick("left")
+
+		if (gamepad.isPressed("south")) {
+			player.doubleJump()
+		}
+
+		if(leftStick.x !== 0) {
+			player.move(leftStick.x * 400, 0)
+		}
+	})
+}
+
+// platform
+add([
+	pos(0, height()),
+	anchor("botleft"),
+	rect(width(), 140),
+	area(),
+	body({isStatic: true}),
+])
+
+// add players on every gamepad connect
+onGamepadConnect((gamepad) => {
+	addPlayer(gamepad)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kaboom",
-	"version": "3000.0.0-alpha.25",
+	"version": "3000.0.0-beta.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kaboom",
-			"version": "3000.0.0-alpha.25",
+			"version": "3000.0.0-beta.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@neutralinojs/neu": "^9.3.1",

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3594,12 +3594,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		return gfx.bgColor.clone()
 	}
 
-	// TODO: return custom Gamepad type with isButtonPressed(), getStick() methods etc
-	// Get connected gamepads
-	function getGamepads(): Gamepad[] {
-		return navigator.getGamepads().filter((g) => g !== null)
-	}
-
 	// TODO: manage global velocity here?
 	function pos(...args: Vec2Args): PosComp {
 
@@ -6355,14 +6349,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		game.ev.on("resize", action)
 	}
 
-	function onGamepadConnect(action: (gamepad: Gamepad) => void) {
-		game.ev.on("gamepadConnect", action)
-	}
-
-	function onGamepadDisconnect(action: (gamepad: Gamepad) => void) {
-		game.ev.on("gamepadDisconnect", action)
-	}
-
 	function onError(action: (err: Error) => void) {
 		game.ev.on("error", action)
 	}
@@ -6593,8 +6579,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		onLoad,
 		onLoading,
 		onResize,
-		onGamepadConnect,
-		onGamepadDisconnect,
+		onGamepadConnect: app.onGamepadConnect,
+		onGamepadDisconnect: app.onGamepadDisconnect,
 		onError,
 		onCleanup,
 		// misc
@@ -6608,7 +6594,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		getGravity,
 		setBackground,
 		getBackground,
-		getGamepads,
+		getGamepads: app.getGamepads,
 		// obj
 		add,
 		destroy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -701,13 +701,13 @@ export interface KaboomCtx {
 	 *
 	 * @since v3000.0
 	 */
-	onGamepadConnect(action: (gamepad: Gamepad) => void): void,
+	onGamepadConnect(action: (gamepad: KGamePad) => void): void,
 	/**
 	 * Register an event that runs when a gamepad is disconnected.
 	 *
 	 * @since v3000.0
 	 */
-	onGamepadDisconnect(action: (gamepad: Gamepad) => void): void,
+	onGamepadDisconnect(action: (gamepad: KGamePad) => void): void,
 	/**
 	 * Register an event that runs once when 2 game objs with certain tags collides (required to have area() component).
 	 *
@@ -1444,7 +1444,7 @@ export interface KaboomCtx {
 	 *
 	 * @since v3000.0
 	 */
-	getGamepads(): Gamepad[],
+	getGamepads(): KGamePad[],
 	/**
 	 * Set cursor style (check Cursor type for possible values). Cursor will be reset to "default" every frame so use this in an per-frame action.
 	 *
@@ -2333,10 +2333,17 @@ export type GamepadDef = {
 	sticks: Partial<Record<GamepadStick, { x: number, y: number }>>,
 }
 
+/** A Kaboom's gamepad */
 export type KGamePad = {
+	/** The order of the gamepad in the gamepad list. */
+	index: number;
+	/** If certain button is pressed. */
 	isPressed(b: GamepadButton): boolean,
+	/** If certain button is held down. */
 	isDown(b: GamepadButton): boolean,
+	/** If certain button is released. */
 	isReleased(b: GamepadButton): boolean,
+	/** Get the value of a stick. */
 	getStick(stick: GamepadStick): Vec2,
 }
 


### PR DESCRIPTION
There's the update of the first gamepad pr.

Now Kaboom has a `mergedGamepadState`, where is combined all gamepads inputs, and a `gamepadsState`, where is each gamepad state. Now, `getGamepads()` works, and returns every gamepad registered by Kaboom.

```js
const gamepads = getGamepads();

gamepads[0].isPressed(); 
gamepads[1].isDown();
gamepads[2].isReleased();
gamepads[3].getStick();
gamepads[4].index // the index in the browser count of gamepads
```

