### PR TITLE
fix #716

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3174,7 +3174,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 			get(t: Tag | Tag[], opts: GetOpt = {}): GameObj[] {
 				let list: GameObj[] = opts.recursive
-					? this.children.flatMap((child) => [child, ...child.children])
+					? this.children.flatMap(function recurse(child) {
+						return [child, ...child.children.flatMap(recurse)]
+					})
 					: this.children
 				list = list.filter((child) => t ? child.is(t) : true)
 				if (opts.liveUpdate) {


### PR DESCRIPTION
It looks like the recursive setting inside of `game.root.get` was not fully recursive, you needed to call `flatMap` on the children as well:

```js
this.children.flatMap(function recurse(child) {
   return [child, ...child.children.flatMap(recurse)]
})
```

I am pretty sure it fixes the issue ( #716 ) as described:

![image](https://github.com/replit/kaboom/assets/18319310/81e80245-8e0c-46f6-9a27-242849d31930)

