### PR TITLE
fix: ignore errors from other sources

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2874,6 +2874,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		if (e.error) {
 			handleErr(e.error)
 		} else {
+			// ignore errors from somewhere else, e.g. iframes
+			if (e.message === "Script error.") return
+
 			handleErr(new Error(e.message))
 		}
 	}


### PR DESCRIPTION
This e.g. happens with iframes.
Seems to fix #466

For ref see:
- https://sentry.io/answers/script-error/
- https://scoutapm.com/blog/script-errors