### PR TITLE
empty components and plugins with options

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -112,7 +112,6 @@ import type {
 	AnchorComp,
 	ZComp,
 	FollowComp,
-	MoveComp,
 	OffScreenCompOpt,
 	OffScreenComp,
 	AreaCompOpt,
@@ -136,12 +135,12 @@ import type {
 	FixedComp,
 	StayComp,
 	HealthComp,
-	LifespanComp,
 	LifespanCompOpt,
 	StateComp,
 	Debug,
 	KaboomPlugin,
 	MergeObj,
+	EmptyComp,
 	LevelComp,
 	Edge,
 	TileComp,
@@ -3734,7 +3733,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 	}
 
-	function move(dir: number | Vec2, speed: number): MoveComp {
+	function move(dir: number | Vec2, speed: number): EmptyComp {
 		const d = typeof dir === "number" ? Vec2.fromAngle(dir) : dir.unit()
 		return {
 			id: "move",
@@ -4859,7 +4858,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 	}
 
-	function lifespan(time: number, opt: LifespanCompOpt = {}): LifespanComp {
+	function lifespan(time: number, opt: LifespanCompOpt = {}): EmptyComp {
 		if (time == null) {
 			throw new Error("lifespan() requires time")
 		}

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -477,7 +477,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			const tex = new Texture(0, 0, opt)
 			tex.bind()
 			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img)
+			// @ts-ignore
 			tex.width = img.width
+			// @ts-ignore
 			tex.height = img.height
 			tex.unbind()
 			tex.src = img
@@ -519,14 +521,18 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			this.ctx = this.canvas.getContext("2d")
 		}
 		add(img: TexImageSource): [Texture, Quad] {
+			// @ts-ignore
 			if (img.width > this.canvas.width || img.height > this.canvas.height) {
+				// @ts-ignore
 				throw new Error(`Texture size (${img.width} x ${img.height}) exceeds limit (${this.canvas.width} x ${this.canvas.height})`)
 			}
+			// @ts-ignore
 			if (this.x + img.width > this.canvas.width) {
 				this.x = 0
 				this.y += this.curHeight
 				this.curHeight = 0
 			}
+			// @ts-ignore
 			if (this.y + img.height > this.canvas.height) {
 				this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
 				this.tex = Texture.fromImage(this.canvas)
@@ -535,8 +541,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				this.curHeight = 0
 			}
 			const pos = new Vec2(this.x, this.y)
+			// @ts-ignore
 			this.x += img.width
+			// @ts-ignore
 			if (img.height > this.curHeight) {
+				// @ts-ignore
 				this.curHeight = img.height
 			}
 			if (img instanceof ImageData) {
@@ -548,7 +557,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			return [this.tex, new Quad(
 				pos.x / this.canvas.width,
 				pos.y / this.canvas.height,
+				// @ts-ignore
 				img.width / this.canvas.width,
+				// @ts-ignore
 				img.height / this.canvas.height,
 			)]
 		}
@@ -1158,7 +1169,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		opt: LoadSpriteOpt = {},
 	): SpriteData {
 		const canvas = document.createElement("canvas")
+		// @ts-ignore
 		const width = images[0].width
+		// @ts-ignore
 		const height = images[0].height
 		canvas.width = width * images.length
 		canvas.height = height
@@ -5079,17 +5092,25 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		window.localStorage[key] = JSON.stringify(data)
 	}
 
-	function plug<T>(plugin: KaboomPlugin<T>): MergeObj<T> & KaboomCtx {
+	function plug<T extends Record<string, any>>(plugin: KaboomPlugin<T>, ...args: any): KaboomCtx & T {
 		const funcs = plugin(ctx)
-		for (const k in funcs) {
+		let funcsObj: T
+		if (typeof funcs === "function") {
+			const plugWithOptions = funcs(...args)
+			funcsObj = plugWithOptions(ctx)
+		}
+		else {
+			funcsObj = funcs
+		}
+		for (const k in funcsObj) {
 			// @ts-ignore
-			ctx[k] = funcs[k]
+			ctx[k] = funcsObj[k]
 			if (gopt.global !== false) {
 				// @ts-ignore
-				window[k] = funcs[k]
+				window[k] = funcsObj[k]
 			}
 		}
-		return ctx as unknown as MergeObj<T> & KaboomCtx
+		return ctx as KaboomCtx & T
 	}
 
 	function center(): Vec2 {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -476,9 +476,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			const tex = new Texture(0, 0, opt)
 			tex.bind()
 			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img)
-			// @ts-ignore
 			tex.width = img.width
-			// @ts-ignore
 			tex.height = img.height
 			tex.unbind()
 			tex.src = img
@@ -520,18 +518,14 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			this.ctx = this.canvas.getContext("2d")
 		}
 		add(img: TexImageSource): [Texture, Quad] {
-			// @ts-ignore
 			if (img.width > this.canvas.width || img.height > this.canvas.height) {
-				// @ts-ignore
 				throw new Error(`Texture size (${img.width} x ${img.height}) exceeds limit (${this.canvas.width} x ${this.canvas.height})`)
 			}
-			// @ts-ignore
 			if (this.x + img.width > this.canvas.width) {
 				this.x = 0
 				this.y += this.curHeight
 				this.curHeight = 0
 			}
-			// @ts-ignore
 			if (this.y + img.height > this.canvas.height) {
 				this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
 				this.tex = Texture.fromImage(this.canvas)
@@ -540,11 +534,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				this.curHeight = 0
 			}
 			const pos = new Vec2(this.x, this.y)
-			// @ts-ignore
 			this.x += img.width
-			// @ts-ignore
 			if (img.height > this.curHeight) {
-				// @ts-ignore
 				this.curHeight = img.height
 			}
 			if (img instanceof ImageData) {
@@ -556,9 +547,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			return [this.tex, new Quad(
 				pos.x / this.canvas.width,
 				pos.y / this.canvas.height,
-				// @ts-ignore
 				img.width / this.canvas.width,
-				// @ts-ignore
 				img.height / this.canvas.height,
 			)]
 		}
@@ -1168,9 +1157,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		opt: LoadSpriteOpt = {},
 	): SpriteData {
 		const canvas = document.createElement("canvas")
-		// @ts-ignore
 		const width = images[0].width
-		// @ts-ignore
 		const height = images[0].height
 		canvas.width = width * images.length
 		canvas.height = height

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@
  * k.vec2(...)
  * ```
  */
-declare function kaboom<T extends PluginList<unknown> = undefined>(options?: KaboomOpt<T>): T extends undefined ? KaboomCtx : KaboomCtx & MergePlugins<T>;
+declare function kaboom<T extends PluginList<unknown> = [undefined]>(options?: KaboomOpt<T>): T extends [undefined] ? KaboomCtx : KaboomCtx & MergePlugins<T>;
 
 /**
  * Context handle that contains every kaboom function.

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@
  * k.vec2(...)
  * ```
  */
-declare function kaboom<T = any>(options?: KaboomOpt<T>): KaboomCtx & MergePlugins<T>;
+declare function kaboom<T extends PluginList<unknown> = undefined>(options?: KaboomOpt<T>): T extends undefined ? KaboomCtx : KaboomCtx & MergePlugins<T>;
 
 /**
  * Context handle that contains every kaboom function.
@@ -2335,10 +2335,10 @@ type Defined<T> = T extends any ? Pick<T, { [K in keyof T]-?: T[K] extends undef
 type Expand<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
 export type MergeObj<T> = Expand<UnionToIntersection<Defined<T>>>
 export type MergeComps<T> = Omit<MergeObj<T>, keyof Comp>
-export type MergePlugins<T = any> = MergeObj<ReturnType<T extends (...args: any) => any ? T : never>>
+export type MergePlugins<T extends PluginList<any>> = MergeObj<ReturnType<T[number]>>
 
 export type CompList<T> = Array<T | Tag>
-export type PluginList<T> = Array<T | KaboomPlugin<T extends Array<KaboomPlugin<any>> ? T[number] : never>>
+export type PluginList<T> = Array<T | KaboomPlugin<any>>
 
 export type Key =
 	| "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"
@@ -2405,7 +2405,7 @@ export type GameObjInspect = Record<Tag, string | null>
 /**
  * Kaboom configurations.
  */
-export interface KaboomOpt<T = any> {
+export interface KaboomOpt<T extends PluginList<any> = undefined> {
 	/**
 	 * Width of game.
 	 */
@@ -2505,7 +2505,7 @@ export interface KaboomOpt<T = any> {
 	/**
 	 * List of plugins to import.
 	 */
-	plugins?: PluginList<T>,
+	plugins?: T,
 	/**
 	 * Enter burp mode.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2222,7 +2222,7 @@ export interface KaboomCtx {
 	 *
 	 * @section Misc
 	 */
-	plug<T>(plugin: KaboomPlugin<T>): void,
+	plug<T extends Record<string, any>>(plugin: KaboomPlugin<T>): KaboomCtx & T,
 	/**
 	 * Take a screenshot and get the dataurl of the image.
 	 *
@@ -2398,14 +2398,14 @@ export type KGamePad = {
 }
 
 /**
- * Inspect info for a character.
+ * Inspect info for a game object.
  */
 export type GameObjInspect = Record<Tag, string | null>
 
 /**
  * Kaboom configurations.
  */
-export interface KaboomOpt<T extends PluginList<any> = undefined> {
+export interface KaboomOpt<T extends PluginList<any> = any> {
 	/**
 	 * Width of game.
 	 */
@@ -2512,7 +2512,7 @@ export interface KaboomOpt<T extends PluginList<any> = undefined> {
 	burp?: boolean,
 }
 
-export type KaboomPlugin<T> = (k: KaboomCtx) => T
+export type KaboomPlugin<T> = (k: KaboomCtx) => T | ((...args: any) => (k: KaboomCtx) => T)
 
 /**
  * Base interface of all game objects.
@@ -4783,7 +4783,7 @@ export interface HealthComp extends Comp {
 }
 
 // TODO: this doesn't work
-export type LifespanComp = Comp
+export type LifespanComp = Comp 
 
 export interface LifespanCompOpt {
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,7 +407,7 @@ export interface KaboomCtx {
 	 * ])
 	 * ```
 	 */
-	move(direction: number | Vec2, speed: number): MoveComp,
+	move(direction: number | Vec2, speed: number): EmptyComp,
 	/**
 	 * Control the behavior of object when it goes out of view.
 	 *
@@ -520,7 +520,7 @@ export interface KaboomCtx {
 	 * ])
 	 * ```
 	 */
-	lifespan(time: number, options?: LifespanCompOpt): LifespanComp,
+	lifespan(time: number, options?: LifespanCompOpt): EmptyComp,
 	/**
 	 * Finite state machine.
 	 *
@@ -3863,6 +3863,11 @@ export interface Comp {
 
 export type GameObjID = number
 
+/**
+ * A component without own properties.
+ */
+export type EmptyComp = { id: string } & Comp;
+
 export interface PosComp extends Comp {
 	/**
 	 * Object's current world position.
@@ -3958,8 +3963,6 @@ export interface FollowComp extends Comp {
 		offset: Vec2,
 	},
 }
-
-export type MoveComp = Comp
 
 export interface OffScreenCompOpt {
 	/**
@@ -4781,9 +4784,6 @@ export interface HealthComp extends Comp {
 	 */
 	onDeath(action: () => void): EventController,
 }
-
-// TODO: this doesn't work
-export type LifespanComp = Comp 
 
 export interface LifespanCompOpt {
 	/**


### PR DESCRIPTION
## Plugins
### No plugins, no type
If there is not a plugins property inside `KaboomOpt`, it only returns `KaboomCtx`

**Before**

![image](https://github.com/replit/kaboom/assets/71136486/78e59f99-2e06-4984-925a-a2a6390d5154)
**Now**

![image](https://github.com/replit/kaboom/assets/71136486/8a01d489-5d26-4c87-993b-b25e86701d8d)

### Options in plugins
Now there's a support for options in plugins

**Normal plugins**
```ts
function logPlugin(k: KaboomCtx) {
    return {
        logWidth() {
            return {
                id: "logWidth",
                log() {
                    k.debug.log(k.width());
                },
            };
        },
        logHeight() {
            return {
                id: "logHeight",
                log() {
                    k.debug.log(k.height());
                },
            };
        },
    };
}
```

**Plugins with options**
```ts
function newLogPlugin(log: "width" | "height") {
    return (k: KaboomCtx) => {
        return {
            logRes() {
                return {
                    id: "hello",
                    log() {
                        k.debug.log(k[log]());
                    },
                }
            },
        };
    };
}
```

They work both
![image](https://github.com/replit/kaboom/assets/71136486/f38581bd-00a0-4d15-9c52-c28fad1eec52)

## Component
### Empty Component type

This was a big odyssey, basically I discovered `MergeObj<T>` doesn't work good when there are types with not required properties (for example, `Comp` type), so my first solution was doing this

```ts
type LifespanComp = Comp & { id: string }
type MoveComp = Comp & { id: string }
```

This fixes the problem without don't have required properties, because now id is required, and we got this result

![image](https://github.com/replit/kaboom/assets/71136486/26fca136-83b3-4ece-bb9d-cdac2738b2f0)

But if there's two duplicated values in an Union, typescript ignores one, so this can happen

![image](https://github.com/replit/kaboom/assets/71136486/ff80ab41-f6d4-4be6-a04d-25954dc159ef)

One is ignored, and looks strange, so I made `EmptyComp`, it represents a Comp with an id, but without nothing more, so, if there are 2 components that returns an `EmptyComp`, it makes sense with the returned object type. It should fix #691

![image](https://github.com/replit/kaboom/assets/71136486/5588396a-3816-4002-8e82-d29db64d02a3)


