### PR TITLE
change default logMax to 10

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -208,7 +208,7 @@ const UV_PAD = 0.1
 const DEF_HASH_GRID_SIZE = 64
 const DEF_FONT_FILTER = "nearest"
 
-const LOG_MAX = 1
+const LOG_MAX = 10
 
 const VERTEX_FORMAT = [
 	{ name: "a_pos", size: 2 },


### PR DESCRIPTION
It is kinda annoying to change the `logMax` every time you want to debug, because probably you want to debug more than one thing, I think 10 lines is a better number by default.