### PR TITLE
doc: fix OffScreenCompOpt.distance default value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3985,7 +3985,7 @@ export interface OffScreenCompOpt {
 	 */
 	destroy?: boolean,
 	/**
-	 * The distance when out of view is triggered (default 64).
+	 * The distance when out of view is triggered (default 200).
 	 *
 	 * @since v3000.0
 	 */


### PR DESCRIPTION
The value is actually 200 in [source](https://github.com/replit/kaboom/blob/aa44a62999b6b510c24e317fc76ffc64524e9680/src/kaboom.ts#L3743C1-L3744C1)