### PR TITLE
fix debug ui when scale & size are set

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -618,7 +618,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		)
 
 		const frameBuffer = (gopt.width && gopt.height)
-			? new FrameBuffer(gopt.width * pixelDensity, gopt.height * pixelDensity)
+			? new FrameBuffer(gopt.width * pixelDensity * gscale, gopt.height * pixelDensity * gscale)
 			: new FrameBuffer(gl.drawingBufferWidth, gl.drawingBufferHeight)
 
 		let bgColor: null | Color = null


### PR DESCRIPTION
hello!!

we noticed that the debug ui is very pixelated when you set size and scale on a game (which my co-developer mentioned in #754).

i dug into the code a bit further, and saw that the framebuffer size is calculated from output size and pixel density – but not game scale! when i add this to the framebuffer size calculation, the debug ui works perfectly on upscaled games.

it does, of course, mean that the game renders more pixels. the performance impact seemed negligible on my tests though, since most of the rendering is done in the gpu anyways. this would be an easy fix to make the debug ui usable in low-resolution games.