### PR TITLE
Add polygon component

### DIFF
--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,0 +1,11 @@
+// Start the game in burp mode
+kaboom()
+
+add([
+	pos(80, 120),
+	polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
+ 	outline(4),
+ 	area(),
+	color(rgb(255,0,0)),
+	opacity(0.2),
+])

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -4,8 +4,8 @@ kaboom()
 add([
 	pos(80, 120),
 	polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
- 	outline(4),
- 	area(),
+	outline(4),
+	area(),
 	color(rgb(255,0,0)),
 	opacity(0.2),
 ])

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,9 +1,8 @@
-// Start the game in burp mode
 kaboom()
 
 add([
-	pos(80, 120),
 	polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
+	pos(80, 120),
 	outline(4),
 	area(),
 	color(rgb(255,0,0)),

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,10 +1,40 @@
-kaboom()
+kaboom(
+)
 
-add([
-	polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
+// Add a thing that follows the mouse
+var CURSOR = "cursor"
+
+const cursor = add([
+	circle(10),
+	area(),
+	pos(),
+	CURSOR,
+])
+
+cursor.onMouseMove(pos => {
+	cursor.pos = pos
+})
+
+// Make a weird shape
+const poly = add([
+	polygon([
+		vec2(300,300),
+		vec2(500,300),
+		vec2(350,600),
+		vec2(300,400),
+	]),
 	pos(80, 120),
 	outline(4),
 	area(),
 	color(rgb(255,0,0)),
 	opacity(0.2),
 ])
+
+// Change the color when the cursor object collides with the polygon
+poly.onCollide(CURSOR, () => {
+	poly.color = poly.color.lighten(100)
+})
+
+poly.onCollideEnd(CURSOR, obj => {
+	poly.color = poly.color.darken(100)
+})

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3965,7 +3965,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				}))
 			},
 			renderArea(this: GameObj<AnchorComp | PolygonComp>) {
-				return new Polygon(pts)
+				return new Polygon(this.pts)
 			},
 			inspect() {
 				return this.pts.map(p => `[${p.x},${p.y}]`).join(",")

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -176,7 +176,7 @@ import type {
 	TexFilter,
 	MaskComp,
 	Mask,
-	Outline,
+	Outline, PolygonComp, PolygonCompOpt,
 } from "./types"
 
 import beanSpriteSrc from "./assets/bean.png"
@@ -3952,6 +3952,44 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	}
 
+	function polygon(pts: Vec2[], opt: PolygonCompOpt = {}): PolygonComp {
+		if(pts.length < 3) throw new Error(`Polygon's need more than two points, ${pts.length} points provided`)
+		return {
+			id: "polygon",
+			pts,
+			draw(this: GameObj<PolygonComp>) {
+				drawPolygon(Object.assign(getRenderProps(this), Object.assign(opt,{
+					pts,
+				})))
+			},
+			renderArea(this: GameObj<AnchorComp | PolygonComp>) {
+				let minX = this.pts[0].x
+				let minY = this.pts[0].y
+				let maxX = this.pts[0].x
+				let maxY =  this.pts[0].y
+
+				for(const pt of this.pts) {
+					if(pt.x <= minX) minX = pt.x
+					if(pt.y <= minY) minY = pt.y
+					if(pt.x >= maxX) maxX = pt.x
+					if(pt.y >= maxY) maxY = pt.y
+				}
+
+				const width = maxX - minX
+				const height = maxY - minY
+
+				return new Rect(
+					new Vec2(0),
+					width,
+					height,
+				)
+			},
+			inspect() {
+				return this.pts.map(p => `[${p.x},${p.y}]`).join(",")
+			},
+		}
+	}
+
 	function rect(w: number, h: number, opt: RectCompOpt = {}): RectComp {
 		return {
 			id: "rect",
@@ -6279,6 +6317,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		area,
 		sprite,
 		text,
+		polygon,
 		rect,
 		circle,
 		uvquad,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3960,31 +3960,12 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			id: "polygon",
 			pts,
 			draw(this: GameObj<PolygonComp>) {
-				drawPolygon(Object.assign(getRenderProps(this), Object.assign(opt,{
-					pts,
-				})))
+				drawPolygon(Object.assign(getRenderProps(this), {
+					pts: this.pts,
+				}))
 			},
 			renderArea(this: GameObj<AnchorComp | PolygonComp>) {
-				let minX = this.pts[0].x
-				let minY = this.pts[0].y
-				let maxX = this.pts[0].x
-				let maxY =  this.pts[0].y
-
-				for(const pt of this.pts) {
-					if(pt.x <= minX) minX = pt.x
-					if(pt.y <= minY) minY = pt.y
-					if(pt.x >= maxX) maxX = pt.x
-					if(pt.y >= maxY) maxY = pt.y
-				}
-
-				const width = maxX - minX
-				const height = maxY - minY
-
-				return new Rect(
-					new Vec2(0),
-					width,
-					height,
-				)
+				return new Polygon(pts)
 			},
 			inspect() {
 				return this.pts.map(p => `[${p.x},${p.y}]`).join(",")

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -176,7 +176,9 @@ import type {
 	TexFilter,
 	MaskComp,
 	Mask,
-	Outline, PolygonComp, PolygonCompOpt,
+	Outline,
+	PolygonComp,
+	PolygonCompOpt,
 } from "./types"
 
 import beanSpriteSrc from "./assets/bean.png"

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,6 +251,21 @@ export interface KaboomCtx {
 	 */
 	text(txt: string, options?: TextCompOpt): TextComp,
 	/**
+	 * Render as a polygon.
+	 *
+	 * @example
+	 * ```js
+	 * // Make a square the hard way
+	 * add([
+	 *     pos(80, 120),
+	 *     polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
+	 *     outline(4),
+	 *     area(),
+	 * ])
+	 * ```
+	 */
+	polygon(pts: Vec2[], opt?: PolygonCompOpt): PolygonComp,
+	/**
 	 * Render as a rectangle.
 	 *
 	 * @example
@@ -4576,6 +4591,7 @@ export interface RectCompOpt {
 	fill?: boolean,
 }
 
+export type PolygonCompOpt = Omit<DrawPolygonOpt,"pts">
 export interface RectComp extends Comp {
 	draw: Comp["draw"],
 	/**
@@ -4592,6 +4608,19 @@ export interface RectComp extends Comp {
 	radius?: number,
 	/**
 	 * @since v3000.0
+	 */
+	renderArea(): Rect,
+}
+
+export interface PolygonComp extends Comp {
+	draw: Comp["draw"],
+
+	/**
+	 * @since 3000.1.13
+	 */
+	pts: Vec2[]
+	/**
+	 * @since 3000.1.13
 	 */
 	renderArea(): Rect,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4616,13 +4616,14 @@ export interface PolygonComp extends Comp {
 	draw: Comp["draw"],
 
 	/**
+	 * Points in the polygon
 	 * @since 3000.1.13
 	 */
 	pts: Vec2[]
 	/**
 	 * @since 3000.1.13
 	 */
-	renderArea(): Rect,
+	renderArea(): Polygon,
 }
 
 export interface CircleCompOpt {


### PR DESCRIPTION
Adds a `polygon` component so we can draw arbitrary shapes. 

Usage example: 
```
kaboom()


// Draw a square the hard way
add([
        polygon([vec2(0,0), vec2(50,0), vec2(50,50), vec2(0,50)]),
	pos(80, 120),
	outline(4),
	area(),
	color(rgb(255,0,0)),
	opacity(0.2),
])
```