### PR TITLE
add `jumpRelease` function to `BodyComp`

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4341,6 +4341,12 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				vel.y = -force || -this.jumpForce
 			},
 
+			jumpRelease(force?: number | null) {
+				if (vel.y < 0 || force) {
+					vel.y = force ? force : vel.y * 0.5
+				}
+			},
+
 			onGround(this: GameObj, action: () => void): EventController {
 				return this.on("ground", action)
 			},

--- a/src/types.ts
+++ b/src/types.ts
@@ -4847,6 +4847,10 @@ export interface BodyComp extends Comp {
 	 */
 	jump(force?: number): void,
 	/**
+	 * Cut a jump short with a different vertical force, or cut velocity in half if no force provided.
+	 */
+	jumpRelease(force?: number | null): void,
+	/**
 	 * Register an event that runs when a collision is resolved.
 	 *
 	 * @since v3000.0


### PR DESCRIPTION
**Problem:** When jumping with the `jump` function in `BodyComp`, a force is applied but thereafter you can't change the velocity.  What about if you want to: (a) Change the height of jump based on how long the player holds down the jump key? (b) Want to stomp down in the middle of a jump? 

**Solution:** With this function, you can accomplish the points mentioned above with a `jumpRelease` function that lets you change the velocity mid-jump.

Example of use can be seen here:  
https://www.curtiss.me/build-mario-with-kaboom/

(Notice how short or long jumps can be achieved by how long you hold the jump button, or stomping down by pressing down mid-jump)

How it is accomplished in the sample:
- [Stomp](https://github.com/joshuacurtiss/build-mario-with-kaboom/blob/de389944b5466d72a8bb7b32e1bf9828a1e5eba4/src/main.ts#L391-L394)
- [Release jump key](https://github.com/joshuacurtiss/build-mario-with-kaboom/blob/de389944b5466d72a8bb7b32e1bf9828a1e5eba4/src/main.ts#L412-L416)

Thanks for your consideration.