### PR TITLE
Skip zero-width character render

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2219,6 +2219,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 					c2d.fillStyle = "#ffffff"
 					const m = c2d.measureText(ch)
 					let w = Math.ceil(m.width)
+					if (!w) continue
 					let h = font.size
 					if (atlas.outline) {
 						c2d.lineJoin = "round"


### PR DESCRIPTION
My game allows the user to enter text, when there is a zero-width character in the text component, the following error is generated causing the game to stop running, so I added a judgment to skip the rendering of the zero-width character.

```text
Uncaught DOMException: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The source width is 0.
```

https://kaboomjs.com/play?code=eJwlwkEKwjAQBdB15hSfbkygWnsAb%2BFOXMTMQIJtB9IBi6seoF7Sk4j6ePd4Ux19oKTTbLDFcEJk9hdyXYdzliq7GRFPqbp%2FFLaMlGONyaSiTLAsGAvzIAdyJov5pn%2Bv2%2B%2Frv29CSy7poNUfW3wHuoYPK3oqNw%3D%3D&example=add