### PR TITLE
fix: err TS2339

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4270,7 +4270,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 			},
 
-			update(this: GameObj<PosComp | BodyComp>) {
+			update(this: GameObj<PosComp | BodyComp | AreaComp >) {
 
 				if (game.gravity && !this.isStatic) {
 


### PR DESCRIPTION
fixed this:
```
> kaboom@3000.1.17 check
> tsc

src/kaboom.ts:4287:14 - error TS2339: Property 'isColliding' does not exist on type 'GameObj<PosComp | BodyComp>'.

4287        !this.isColliding(curPlatform)
                  ~~~~~~~~~~~


Found 1 error in src/kaboom.ts:4287
```