### PR TITLE
Fix puppeteer deprecated warning

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -12,7 +12,7 @@ const run = async () => {
 	let failed = false
 	console.log("launching browser")
 	const browser = await puppeteer.launch({
-		headless:"new"
+		headless: "new"
 	})
 	console.log("getting examples list")
 	const examples = (await fs.readdir("examples"))

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -11,7 +11,9 @@ const run = async () => {
 
 	let failed = false
 	console.log("launching browser")
-	const browser = await puppeteer.launch()
+	const browser = await puppeteer.launch({
+		headless:"new"
+	})
 	console.log("getting examples list")
 	const examples = (await fs.readdir("examples"))
 		.filter((p) => !p.startsWith(".") && p.endsWith(".js"))


### PR DESCRIPTION
Addressing the Puppeteer Headless Deprecation Warning
```
  Puppeteer old Headless deprecation warning:
    In the near future `headless: true` will default to the new Headless mode
    for Chrome instead of the old Headless implementation. For more
    information, please see https://developer.chrome.com/articles/new-headless/.
    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`
    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.
```