### PR TITLE
Fix a typo in the create-kaboom script that causes examples to not be downloaded when using the download flag

### DIFF
--- a/pkgs/create/create.js
+++ b/pkgs/create/create.js
@@ -164,7 +164,7 @@ if (opts["example"]) {
 
 	const example = await request({
 		hostname: "raw.githubusercontent.com",
-		path: `replit/kaboom/master/example/${opts["example"]}.js`,
+		path: `replit/kaboom/master/examples/${opts["example"]}.js`,
 		method: "GET",
 	})
 


### PR DESCRIPTION
The download function had "example" in the path name instead of "examples" which resulted in 404 errors when you tried to load in an example when creating a new kaboom project via npm