### PR TITLE
Fixing assets paths in the postEffect example

### DIFF
--- a/examples/postEffect.js
+++ b/examples/postEffect.js
@@ -9,7 +9,7 @@ loadSprite("coin", "/sprites/coin.png")
 loadSprite("spike", "/sprites/spike.png")
 loadSprite("grass", "/sprites/grass.png")
 loadSprite("ghosty", "/sprites/ghosty.png")
-loadSound("score", "/examples/sounds/score.mp3")
+loadSound("score", "/static/examples/sounds/score.mp3")
 
 const effects = {
 	crt: () => ({
@@ -34,7 +34,7 @@ const effects = {
 }
 
 for (const effect in effects) {
-	loadShaderURL(effect, null, `/examples/shaders/${effect}.frag`)
+	loadShaderURL(effect, null, `/static/examples/shaders/${effect}.frag`)
 }
 
 let curEffect = 0


### PR DESCRIPTION
Right now demo doesn't work properly :(

![image](https://github.com/replit/kaboom/assets/25204240/a65008e4-807c-4cc4-ac3b-a0472bc003fa)
