### PR TITLE
Fixing bugSound path in the loader example

### DIFF
--- a/examples/loader.js
+++ b/examples/loader.js
@@ -31,7 +31,7 @@ load(new Promise((res) => {
 load(fetch("https://kaboomjs.com/"))
 
 // You can also use the handle returned by loadXXX() as the resource handle
-const bugSound = loadSound("bug", "/examples/sounds/bug.mp3")
+const bugSound = loadSound("bug", "/static/examples/sounds/bug.mp3")
 
 volume(0.1)
 


### PR DESCRIPTION
![image](https://github.com/replit/kaboom/assets/25204240/956d9a21-234d-4438-9db8-76598d048593)
