### PR TITLE
Fixing asset path in the sprite example

### DIFF
--- a/examples/sprite.js
+++ b/examples/sprite.js
@@ -9,7 +9,7 @@ kaboom({
 })
 
 // Loading a multi-frame sprite
-loadSprite("dino", "/examples/sprites/dino.png", {
+loadSprite("dino", "/static/examples/sprites/dino.png", {
 	// The image contains 9 frames layed out horizontally, slice it into individual frames
 	sliceX: 9,
 	// Define animations


### PR DESCRIPTION
![image](https://github.com/replit/kaboom/assets/25204240/b5d7758f-f6e4-43c7-a3bf-9cf52dd00561)
