### PR TITLE
Fixing assets paths in the text example

### DIFF
--- a/examples/text.js
+++ b/examples/text.js
@@ -3,14 +3,14 @@ kaboom({
 })
 
 // Load a custom font from a .ttf file
-loadFont("FlowerSketches", "/examples/fonts/FlowerSketches.ttf")
+loadFont("FlowerSketches", "/static/examples/fonts/FlowerSketches.ttf")
 
 // Load a custom font with options
-loadFont("apl386", "/examples/fonts/apl386.ttf", { outline: 4, filter: "linear" })
+loadFont("apl386", "/static/examples/fonts/apl386.ttf", { outline: 4, filter: "linear" })
 
 // Load custom bitmap font, specifying the width and height of each character in the image
-loadBitmapFont("unscii", "/examples/fonts/unscii_8x8.png", 8, 8)
-loadBitmapFont("4x4", "/examples/fonts/4x4.png", 4, 4)
+loadBitmapFont("unscii", "/static/examples/fonts/unscii_8x8.png", 8, 8)
+loadBitmapFont("4x4", "/static/examples/fonts/4x4.png", 4, 4)
 
 // List of built-in fonts ("o" at the end means the outlined version)
 const builtinFonts = [


### PR DESCRIPTION
![image](https://github.com/replit/kaboom/assets/25204240/94d4cee1-be46-4e48-9716-2e3184193881)
