### PR TITLE
Fixing assets paths in the audio example

### DIFF
--- a/examples/audio.js
+++ b/examples/audio.js
@@ -6,8 +6,8 @@ kaboom({
 	background: [0, 0, 0],
 })
 
-loadSound("bell", "/examples/sounds/bell.mp3")
-loadMusic("OtherworldlyFoe", "/examples/sounds/OtherworldlyFoe.mp3")
+loadSound("bell", "/static/examples/sounds/bell.mp3")
+loadMusic("OtherworldlyFoe", "/static/examples/sounds/OtherworldlyFoe.mp3")
 
 // play() to play audio
 // (This might not play until user input due to browser policy)


### PR DESCRIPTION
![image](https://github.com/replit/kaboom/assets/25204240/bcb43348-8693-4866-b4cd-9404f34498cd)
