### PR TITLE
Fixing asset path in the level example

### DIFF
--- a/examples/level.js
+++ b/examples/level.js
@@ -9,7 +9,7 @@ loadSprite("coin", "/sprites/coin.png")
 loadSprite("spike", "/sprites/spike.png")
 loadSprite("grass", "/sprites/grass.png")
 loadSprite("ghosty", "/sprites/ghosty.png")
-loadSound("score", "/examples/sounds/score.mp3")
+loadSound("score", "/static/examples/sounds/score.mp3")
 
 const SPEED = 480
 


### PR DESCRIPTION
![image](https://github.com/replit/kaboom/assets/25204240/27112470-edeb-45a9-8b06-4cc24ffba1fe)
