### PR TITLE
Added support for arrays in uniforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v3000.2.1
+- added support for arrays in uniforms
+
 ## v3000.2
 - added `loadMusic()` to load streaming audio (doesn't block in loading screen)
 

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -260,7 +260,19 @@ export class Shader {
 				gl.uniform3f(loc, val.r, val.g, val.b)
 			} else if (val instanceof Vec2) {
 				gl.uniform2f(loc, val.x, val.y)
-			}
+			} else if (Array.isArray(val)) {
+				const first = val[0]
+				if (typeof first === "number") {
+					gl.uniform1fv(loc, val)
+				} else if (first instanceof Vec2) {
+					gl.uniform2fv(loc, val.map(v => [v.x, v.y]).flat())
+				} else if (first instanceof Color) {
+					gl.uniform3fv(loc, val.map(v => [v.r, v.g, v.b]).flat())
+				}
+			} else if (typeof val === "object") {
+				throw new Error("Unsupported uniform data type.");
+				// TODO allow for struct like objects to be sent as a uniform
+ 			}
 		}
 	}
 

--- a/src/gfx.ts
+++ b/src/gfx.ts
@@ -270,7 +270,7 @@ export class Shader {
 					gl.uniform3fv(loc, val.map(v => [v.r, v.g, v.b]).flat())
 				}
 			} else if (typeof val === "object") {
-				throw new Error("Unsupported uniform data type.");
+				throw new Error("Unsupported uniform data type.")
 				// TODO allow for struct like objects to be sent as a uniform
  			}
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4882,6 +4882,9 @@ export type UniformValue =
 	| Vec2
 	| Color
 	| Mat4
+	| number[]
+	| Vec2[]
+	| Color[]
 
 export type UniformKey = Exclude<string, "u_tex">
 export type Uniform = Record<UniformKey, UniformValue>


### PR DESCRIPTION
Arrays for shader uniforms. Soon to support struct like objects to be sent as a uniform. For example, Light a = { vec2 position, vec3 color } will be sent as a uniform such that if your shader has the struct Light, it will be able to accept that uniform to link specific variables together.