### PR TITLE
Make Opacity required component for Lifespan.

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4653,10 +4653,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		const fade = opt.fade ?? 0
 		return {
 			id: "lifespan",
+			require: [ "opacity" ],
 			async add(this: GameObj<OpacityComp>) {
 				await wait(time)
-				// TODO: this secretively requires opacity comp, make opacity on every game obj?
-				if (fade > 0 && this.opacity) {
+				this.opacity = this.opacity ?? 1
+				if (fade > 0) {
 					await tween(this.opacity, 0, fade, (a) => this.opacity = a, easings.linear)
 				}
 				this.destroy()


### PR DESCRIPTION
There was no indication that the `lifespan` component requires the `opacity` component. I spent quite sometime debugging it. Until  I tried `fadeIn`, I was then given the error that the `opacity` component was required. So I thought it'd be nice that `lifespan` component gives an error like `fadeIn`.