### PR TITLE
fix unresolveable collisions in beforePhysicsResolve

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4391,10 +4391,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						}
 
 						this.trigger("beforePhysicsResolve", col)
-						other.trigger("beforePhysicsResolve", col.reverse())
+						const rcol = col.reverse()
+						other.trigger("beforePhysicsResolve", rcol)
 
 						// user can mark 'resolved' in beforePhysicsResolve to stop a resolution
-						if (col.resolved) {
+						if (col.resolved || rcol.resolved) {
 							return
 						}
 


### PR DESCRIPTION
This PR fixes an issue where inside "beforePhysicsResolve" collisions could only be cancelled in the "source" GameObject's listener not inside the "target" GameObject's listener, because the reversed collision's `resolved` property wasn't checked.