### PR TITLE
Allow for Oak Interop support (Stringify String typed args in methods)

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,44 @@
+compile = "npm run check; npm run lint; npm run fmt"
+run = "npm run dev"
+hidden = [".config", "package-lock.json", "tsconfig.json"]
+
+[packager]
+language = "nodejs"
+  [packager.features]
+  enabledForHosting = false
+  packageSearch = true
+  guessImports = true
+
+[nix]
+channel = "stable-22_11"
+
+[env]
+XDG_CONFIG_HOME = "$REPL_HOME/.config"
+PATH = "$REPL_HOME/node_modules/.bin:$REPL_HOME/.config/npm/node_global/bin"
+npm_config_prefix = "$REPL_HOME/.config/npm/node_global"
+
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", ".config"]
+
+[languages]
+  [languages.typescript]
+  pattern = "**/{*.ts,*.js,*.tsx,*.jsx,*.json}"
+    [languages.typescript.languageServer]
+    start = "typescript-language-server --stdio"
+
+[deployment]
+run = ["sh", "-c", "npm run start"]
+deploymentTarget = "cloudrun"
+ignorePorts = false
+
+[[ports]]
+localPort = 80
+externalPort = 3000
+
+[[ports]]
+localPort = 3000
+externalPort = 80
+
+[[ports]]
+localPort = 8000
+externalPort = 3001

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,10 @@
+{ pkgs }: {
+    deps = [
+        pkgs.yarn
+        pkgs.esbuild
+        pkgs.nodejs-18_x
+
+        pkgs.nodePackages.typescript
+        pkgs.nodePackages.typescript-language-server
+    ];
+}

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -2823,6 +2823,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			// TODO: recursive
 			removeAll(tag?: Tag) {
 				if (tag) {
+					tag = handleIfOakString(tag)
 					this.get(tag).forEach((obj) => this.remove(obj))
 				} else {
 					for (const child of [...this.children]) this.remove(child)
@@ -2897,6 +2898,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				}
 
 				// tag
+				comp = handleIfOakString(comp)
 				if (typeof comp === "string") {
 					return this.use({
 						id: comp,
@@ -2993,6 +2995,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			unuse(id: Tag) {
+				id = handleIfOakString(id)
 				if (cleanups[id]) {
 					cleanups[id].forEach((e) => e())
 					delete cleanups[id]
@@ -3003,6 +3006,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			c(id: Tag): Comp {
+				id = handleIfOakString(id)
 				return compStates.get(id)
 			},
 
@@ -3012,6 +3016,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						return [child, ...child.children.flatMap(recurse)]
 					})
 					: this.children
+				t = handleIfOakString(t)
 				list = list.filter((child) => t ? child.is(t) : true)
 				if (opts.liveUpdate) {
 					const isChild = (obj) => {
@@ -3056,6 +3061,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			is(tag: Tag | Tag[]): boolean {
+				tag = handleIfOakString(tag)
 				if (tag === "*") {
 					return true
 				}
@@ -3072,6 +3078,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			on(name: string, action: (...args) => void): EventController {
+				name = handleIfOakString(name)
 				const ctrl = events.on(name, action.bind(this))
 				if (onCurCompCleanup) {
 					onCurCompCleanup(() => ctrl.cancel())
@@ -3080,6 +3087,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			trigger(name: string, ...args): void {
+				name = handleIfOakString(name)
 				events.trigger(name, ...args)
 				game.objEvents.trigger(name, this, ...args)
 			},
@@ -3162,6 +3170,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	// add an event to a tag
 	function on(event: string, tag: Tag, cb: (obj: GameObj, ...args) => void): EventController {
+		[event, tag] = handleIfOakStrings(event, tag)
 		if (!game.objEvents[event]) {
 			game.objEvents[event] = new Registry()
 		}
@@ -3220,6 +3229,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		t2: Tag,
 		f: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventController {
+		[t1, t2] = handleIfOakStrings(t1, t2)
 		return on("collide", t1, (a, b, col) => b.is(t2) && f(a, b, col))
 	}
 
@@ -3228,6 +3238,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		t2: Tag,
 		f: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventController {
+		[t1, t2] = handleIfOakStrings(t1, t2)
 		return on("collideUpdate", t1, (a, b, col) => b.is(t2) && f(a, b, col))
 	}
 
@@ -3236,6 +3247,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		t2: Tag,
 		f: (a: GameObj, b: GameObj, col?: Collision) => void,
 	): EventController {
+		[t1, t2] = handleIfOakStrings(t1, t2)
 		return on("collideEnd", t1, (a, b, col) => b.is(t2) && f(a, b, col))
 	}
 
@@ -3258,6 +3270,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	// add an event that runs once when objs with tag t is hovered
 	function onHover(t: Tag, action: (obj: GameObj) => void): EventController {
+		t = handleIfOakString(t)
 		const events = []
 		forAllCurrentAndFuture(t, (obj) => {
 			if (!obj.area)
@@ -3269,6 +3282,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	// add an event that runs once when objs with tag t is hovered
 	function onHoverUpdate(t: Tag, action: (obj: GameObj) => void): EventController {
+		t = handleIfOakString(t)
 		const events = []
 		forAllCurrentAndFuture(t, (obj) => {
 			if (!obj.area)
@@ -3280,6 +3294,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	// add an event that runs once when objs with tag t is unhovered
 	function onHoverEnd(t: Tag, action: (obj: GameObj) => void): EventController {
+		t = handleIfOakString(t)
 		const events = []
 		forAllCurrentAndFuture(t, (obj) => {
 			if (!obj.area)
@@ -3714,6 +3729,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				tag: Tag | ((obj: GameObj, col?: Collision) => void),
 				cb?: (obj: GameObj, col?: Collision) => void,
 			): EventController {
+				tag = handleIfOakString(tag)
 				if (typeof tag === "function" && cb === undefined) {
 					return this.on("collide", tag)
 				} else if (typeof tag === "string") {
@@ -3730,6 +3746,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				tag: Tag | ((obj: GameObj, col?: Collision) => void),
 				cb?: (obj: GameObj, col?: Collision) => void,
 			): EventController {
+				tag = handleIfOakString(tag)
 				if (typeof tag === "function" && cb === undefined) {
 					return this.on("collideUpdate", tag)
 				} else if (typeof tag === "string") {
@@ -3742,6 +3759,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				tag: Tag | ((obj: GameObj) => void),
 				cb?: (obj: GameObj) => void,
 			): EventController {
+				tag = handleIfOakString(tag)
 				if (typeof tag === "function" && cb === undefined) {
 					return this.on("collideEnd", tag)
 				} else if (typeof tag === "string") {
@@ -3833,6 +3851,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		let curAnimDir: -1 | 1 | null = null
 		const spriteLoadedEvent = new Event<[SpriteData]>()
 
+		src = handleIfOakString(src)
+		
 		if (!src) {
 			throw new Error("Please pass the resource name or data to sprite()")
 		}
@@ -4038,6 +4058,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 			play(this: GameObj<SpriteComp>, name: string, opt: SpriteAnimPlayOpt = {}) {
 
+				name = handleIfOakString(name)
+
 				if (!spriteData) {
 					spriteLoadedEvent.add(() => this.play(name, opt))
 					return
@@ -4130,6 +4152,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 	function text(t: string, opt: TextCompOpt = {}): TextComp {
 
+		t = handleIfOakString(t)
+		
 		function update(obj: GameObj<TextComp | any>) {
 
 			const ftext = formatText(Object.assign(getRenderProps(obj), {
@@ -4615,6 +4639,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	function shader(id: string, uniform?: Uniform | (() => Uniform)): ShaderComp {
+		id = handleIfOakString(id)
 		return {
 			id: "shader",
 			shader: id,
@@ -4717,6 +4742,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			throw new Error("state() requires an initial state")
 		}
 
+		initState = handleIfOakString(initState)
+		stateList & (stateList = handleIfOakStrings(...stateList))
+
 		const events = {}
 
 		function initStateEvents(state: string) {
@@ -4749,6 +4777,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 			enterState(state: string, ...args) {
 
+				state = handleIfOakString(state)
+
 				didFirstEnter = true
 
 				if (stateList && !stateList.includes(state)) {
@@ -4760,13 +4790,15 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 				if (transitions) {
 
 					// check if the transition is legal, if transition graph is defined
-					if (!transitions?.[oldState]) {
+					if (!handleIfOakString(transitions?.[oldState])) {
 						return
 					}
 
 					const available = typeof transitions[oldState] === "string"
 						? [transitions[oldState]]
 						: transitions[oldState] as string[]
+
+					available = handleIfOakString(available)
 
 					if (!available.includes(state)) {
 						throw new Error(`Cannot transition state from "${oldState}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`)
@@ -4782,22 +4814,27 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			onStateTransition(from: string, to: string, action: () => void): EventController {
+				[from, to] = handleIfOakStrings(from, to)
 				return on("enter", `${from} -> ${to}`, action)
 			},
 
 			onStateEnter(state: string, action: () => void): EventController {
+				state = handleIfOakString(state)
 				return on("enter", state, action)
 			},
 
 			onStateUpdate(state: string, action: () => void): EventController {
+				[from, to] = handleIfOakStrings(from, to)
 				return on("update", state, action)
 			},
 
 			onStateDraw(state: string, action: () => void): EventController {
+				state = handleIfOakString(state)
 				return on("draw", state, action)
 			},
 
 			onStateEnd(state: string, action: () => void): EventController {
+				state = handleIfOakString(state)
 				return on("end", state, action)
 			},
 
@@ -4866,10 +4903,13 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	function scene(id: SceneName, def: SceneDef) {
+		id = handleIfOakString(id)
 		game.scenes[id] = def
 	}
 
 	function go(name: SceneName, ...args) {
+
+		name = handleIfOakString(name)
 
 		if (!game.scenes[name]) {
 			throw new Error(`Scene not found: ${name}`)

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -346,16 +346,16 @@ function createEmptyAudioBuffer(ctx: AudioContext) {
 }
 
 // Handle Oak strings.
-function handleOakString(string: any) {
+function handleIfOakString(string: any) {
 	let stringOrOSTR = string
-	if (typeof stringOrOSTR == 'object' && '__mark_oak_string' in stringOrOSTR) {
+	if (!!stringOrOSTR && typeof stringOrOSTR == "object" && "__mark_oak_string" in stringOrOSTR) {
 		stringOrOSTR = stringOrOSTR.toString()
 	}
 	return stringOrOSTR
 }
 
 function handleIfOakStrings(...strings: any[]) {
-	return strings.map(handleOakString)
+	return strings.map(handleIfOakString)
 }
 
 // only exports one kaboom() which contains all the state
@@ -587,7 +587,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 
 		static fromURL(url: string, opt: LoadSpriteOpt = {}): Promise<SpriteData> {
-			url = handleIfOakString(url)
 			return loadImg(url).then((img) => SpriteData.fromImage(img, opt))
 		}
 
@@ -608,8 +607,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 
 		static fromURL(url: string): Promise<SoundData> {
-			url = handleIfOakString(url)
-			
 			if (isDataURL(url)) {
 				return SoundData.fromArrayBuffer(dataURLToArrayBuffer(url))
 			} else {
@@ -844,7 +841,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		src: LoadSpriteSrc,
 		data: SpriteAtlasData | string,
 	): Asset<Record<string, SpriteData>> {
-		[src, data] = handleIfOakStrings()
+		[src, data] = handleIfOakStrings(src, data)
 		src = fixURL(src)
 		if (typeof data === "string") {
 			return load(new Promise((res, rej) => {
@@ -3857,11 +3854,6 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			throw new Error("Please pass the resource name or data to sprite()")
 		}
 
-		// Handle Oak strings.
-		if ('__mark_oak_string' in src) {
-			src = src.toString()
-		}
-
 		const calcTexScale = (tex: Texture, q: Quad, w?: number, h?: number): Vec2 => {
 			const scale = vec2(1, 1)
 			if (w && h) {
@@ -4743,7 +4735,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 
 		initState = handleIfOakString(initState)
-		stateList & (stateList = handleIfOakStrings(...stateList))
+		stateList && (stateList = handleIfOakStrings(...stateList))
 
 		const events = {}
 
@@ -4794,11 +4786,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 						return
 					}
 
+					transitions[oldState] = handleIfOakString(transitions[oldState])
 					const available = typeof transitions[oldState] === "string"
 						? [transitions[oldState]]
 						: transitions[oldState] as string[]
 
-					available = handleIfOakString(available)
 
 					if (!available.includes(state)) {
 						throw new Error(`Cannot transition state from "${oldState}" to "${state}". Available transitions: ${available.map((s) => `"${s}"`).join(", ")}`)
@@ -4824,7 +4816,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			},
 
 			onStateUpdate(state: string, action: () => void): EventController {
-				[from, to] = handleIfOakStrings(from, to)
+				state = handleIfOakString(state)
 				return on("update", state, action)
 			},
 

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -345,6 +345,19 @@ function createEmptyAudioBuffer(ctx: AudioContext) {
 	return ctx.createBuffer(1, 1, 44100)
 }
 
+// Handle Oak strings.
+function handleOakString(string: any) {
+	let stringOrOSTR = string
+	if (typeof stringOrOSTR == 'object' && '__mark_oak_string' in stringOrOSTR) {
+		stringOrOSTR = stringOrOSTR.toString()
+	}
+	return stringOrOSTR
+}
+
+function handleIfOakStrings(...strings: any[]) {
+	return strings.map(handleOakString)
+}
+
 // only exports one kaboom() which contains all the state
 export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
@@ -574,6 +587,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 
 		static fromURL(url: string, opt: LoadSpriteOpt = {}): Promise<SpriteData> {
+			url = handleIfOakString(url)
 			return loadImg(url).then((img) => SpriteData.fromImage(img, opt))
 		}
 
@@ -594,6 +608,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		}
 
 		static fromURL(url: string): Promise<SoundData> {
+			url = handleIfOakString(url)
+			
 			if (isDataURL(url)) {
 				return SoundData.fromArrayBuffer(dataURLToArrayBuffer(url))
 			} else {
@@ -731,12 +747,14 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	// global load path prefix
 	function loadRoot(path?: string): string {
 		if (path !== undefined) {
+			path = handleIfOakString(path)
 			assets.urlPrefix = path
 		}
 		return assets.urlPrefix
 	}
 
 	function loadJSON(name, url) {
+		[name, url] = handleIfOakStrings(name, url)
 		return assets.custom.add(name, fetchJSON(url))
 	}
 
@@ -773,6 +791,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		src: string | BinaryData,
 		opt: LoadFontOpt = {},
 	): Asset<FontData> {
+		[name, src] = handleIfOakStrings(name, src)
 		const font = new FontFace(name, typeof src === "string" ? `url(${src})` : src)
 		document.fonts.add(font)
 		return assets.fonts.add(name, font.load().catch((err) => {
@@ -789,6 +808,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		gh: number,
 		opt: LoadBitmapFontOpt = {},
 	): Asset<BitmapFontData> {
+		[name, src] = handleIfOakStrings(name, src)
 		return assets.bitmapFonts.add(name, loadImg(src)
 			.then((img) => {
 				return makeFont(
@@ -824,6 +844,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		src: LoadSpriteSrc,
 		data: SpriteAtlasData | string,
 	): Asset<Record<string, SpriteData>> {
+		[src, data] = handleIfOakStrings()
 		src = fixURL(src)
 		if (typeof data === "string") {
 			return load(new Promise((res, rej) => {
@@ -895,6 +916,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 			anims: {},
 		},
 	): Asset<SpriteData> {
+		[name, src] = handleIfOakStrings(name, src)
 		src = fixURL(src)
 		if (Array.isArray(src)) {
 			if (src.some((s) => typeof s === "string")) {
@@ -917,7 +939,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 	}
 
 	function loadPedit(name: string | null, src: string | PeditFile): Asset<SpriteData> {
-
+		
+		[name, src] = handleIfOakStrings(name, src)
 		src = fixURL(src)
 
 		// eslint-disable-next-line
@@ -952,6 +975,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		jsonSrc: string | AsepriteData,
 	): Asset<SpriteData> {
 
+		[name, imgSrc, jsonSrc] = handleIfOakStrings(name, imgSrc, jsonSrc)
 		imgSrc = fixURL(imgSrc)
 		jsonSrc = fixURL(jsonSrc)
 
@@ -1000,6 +1024,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		vert?: string,
 		frag?: string,
 	) {
+		[name, vert, frag] = handleIfOakStrings(name, vert, frag)
 		return assets.shaders.addLoaded(name, makeShader(vert, frag))
 	}
 
@@ -1008,6 +1033,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		vert?: string,
 		frag?: string,
 	): Asset<ShaderData> {
+		[name, vert, frag] = handleIfOakStrings(name, vert, frag)
 		vert = fixURL(vert)
 		frag = fixURL(frag)
 		const resolveUrl = (url?: string) =>
@@ -1026,6 +1052,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		name: string | null,
 		src: string | ArrayBuffer,
 	): Asset<SoundData> {
+		[name, src] = handleIfOakStrings(name, src)
 		src = fixURL(src)
 		return assets.sounds.add(
 			name,
@@ -1039,36 +1066,44 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		name: string | null,
 		url: string,
 	) {
+		[name, url] = handleIfOakStrings(name, url)
 		const a = new Audio(url)
 		a.preload = "auto"
 		return assets.music[name] = fixURL(url)
 	}
 
 	function loadBean(name: string = "bean"): Asset<SpriteData> {
+		name = handleIfOakString(name)
 		return loadSprite(name, beanSpriteSrc)
 	}
 
 	function getSprite(name: string): Asset<SpriteData> | void {
+		name = handleIfOakString(name)
 		return assets.sprites.get(name)
 	}
 
 	function getSound(name: string): Asset<SoundData> | void {
+		name = handleIfOakString(name)
 		return assets.sounds.get(name)
 	}
 
 	function getFont(name: string): Asset<FontData> | void {
+		name = handleIfOakString(name)
 		return assets.fonts.get(name)
 	}
 
 	function getBitmapFont(name: string): Asset<BitmapFontData> | void {
+		name = handleIfOakString(name)
 		return assets.bitmapFonts.get(name)
 	}
 
 	function getShader(name: string): Asset<ShaderData> | void {
+		name = handleIfOakString(name)
 		return assets.shaders.get(name)
 	}
 
 	function getAsset(name: string): Asset<any> | void {
+		name = handleIfOakString(name)
 		return assets.custom.get(name)
 	}
 
@@ -1292,6 +1327,8 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		src: string | SoundData | Asset<SoundData> | MusicData | Asset<MusicData>,
 		opt: AudioPlayOpt = {},
 	): AudioPlay {
+
+		src = handleIfOakString(src)
 
 		if (typeof src === "string" && assets.music[src]) {
 			return playMusic(assets.music[src], opt)
@@ -2644,6 +2681,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		drawCalls: () => gfx.lastDrawCalls,
 		clearLog: () => game.logs = [],
 		log: (msg) => {
+			msg = handleIfOakString(msg)
 			const max = gopt.logMax ?? LOG_MAX
 			game.logs.unshift({
 				msg: msg,
@@ -3797,6 +3835,11 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
 		if (!src) {
 			throw new Error("Please pass the resource name or data to sprite()")
+		}
+
+		// Handle Oak strings.
+		if ('__mark_oak_string' in src) {
+			src = src.toString()
 		}
 
 		const calcTexScale = (tex: Texture, q: Quad, w?: number, h?: number): Vec2 => {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3462,6 +3462,9 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 		if (!o) {
 			throw new Error("Please define an anchor")
 		}
+
+		o = handleIfOakString(o)
+    
 		return {
 			id: "anchor",
 			anchor: o,


### PR DESCRIPTION
I have added helpers for using a compiled language, Oak (Oaklang.org), into the code.

![image](https://github.com/replit/kaboom/assets/126259962/53cf934a-2207-44c3-95ed-748a56055036)

These allow for Oak String payloads (`{__mark_oak_string: true, assign: ƒ, push: ƒ, toString: ƒ, valueOf: ƒ, …}`) to be handled into strings.

In case that another compiled language that needs to convert a payload of some sort into a string, this function can be refactored to handle the other cases around the main `kaboom.ts` file. 