### PR TITLE
chore(dev.md): remove old instructions from dev.md

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -6,10 +6,10 @@ To start developing Kaboom, first clone the github repo
 $ git clone https://github.com/replit/kaboom
 ```
 
-Run the `setup` command to install the dev packages
+Run the `install` command to install the dev packages
 
 ```sh
-$ npm run setup
+$ npm run install
 ```
 
 Then run the `dev` command to start the dev server
@@ -19,8 +19,6 @@ $ npm run dev
 ```
 
 This will start a server that serves the kaboom website, and build the source files on file change.
-
-As you're making changes to kaboom source under `src/`, go to [http://localhost:8000/demo](http://localhost:8000/demo) and edit or create demos under `demo/` to test whatever you're changing.
 
 Also remember to run `check` to check for typescript errors and linting.
 
@@ -36,7 +34,6 @@ $ npm run check
 - `examples/` examples
 - `pkgs/` other related packages such `kaboom-create`
 - `scripts/` development scripts
-- `site/` kaboom website source code
 - `sprites/` some examples sprites
 - `src/` kaboom library source code
 ## Source code overview


### PR DESCRIPTION
Removed outdated instructions:
- "run setup" is no longer a command in the node package
- localhost:8000/demo no longer exists
- /site is no longer in the project's directory