### PR TITLE
Improved docs regarding custom events usage

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -672,9 +672,12 @@ export interface KaboomCtx {
 	 * // a custom event can be defined manually
 	 * // by passing a name and a callback function
 	 * on("talk", (message, posX, posY) => {
-	 *     add([text(message), pos(posX, posY - 100)])
+	 *     add([
+	 * 		text(message), 
+	 * 		pos(posX, posY - 100)
+	 * 	   ])
 	 * })
-	 * onKeyPress("Space", () => {
+	 * onKeyPress("space", () => {
 	 *    	// the trigger method on game objs can be used to trigger a custom event
 	 * 		npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
 	 * })

--- a/src/types.ts
+++ b/src/types.ts
@@ -662,14 +662,14 @@ export interface KaboomCtx {
 	 *
 	 * @example
 	 * ```js
-   * // will display a message on the screen
-   * on("talk", (message, posX, posY) => {
-   *     add([text(message), pos(posX, posY - 100)])
-   * })
-   * onKeyPress("Space", () => {
-   *    npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
-   * })
-   * 
+	 * // will display a message on the screen
+	 * on("talk", (message, posX, posY) => {
+	 *     add([text(message), pos(posX, posY - 100)])
+	 * })
+	 * onKeyPress("Space", () => {
+	 *    npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
+	 * })
+	 * 
 	 * ```
 	 */
 	on(event: string, tag: Tag, action: (obj: GameObj, ...args: any) => void): EventController,

--- a/src/types.ts
+++ b/src/types.ts
@@ -656,18 +656,27 @@ export interface KaboomCtx {
 	 */
 	agent(opt?: AgentCompOpt): AgentComp,
 	/**
-	 * Register a custom event available to all game objs that triggers it.
+	 * Register an event on all game objs with certain tag.
 	 *
 	 * @section Events
 	 *
 	 * @example
 	 * ```js
-	 * // will display a message on the screen
+	 * // a custom event defined by body() comp
+	 * // every time an obj with tag "bomb" hits the floor, destroy it and addKaboom()
+	 * on("ground", "bomb", (bomb) => {
+	 *     destroy(bomb)
+	 *     addKaboom(bomb.pos)
+	 * })
+	 * 
+	 * // a custom event can be defined manually
+	 * // by passing a name and a callback function
 	 * on("talk", (message, posX, posY) => {
 	 *     add([text(message), pos(posX, posY - 100)])
 	 * })
 	 * onKeyPress("Space", () => {
-	 *    npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
+	 *    	// the trigger method on game objs can be used to trigger a custom event
+	 * 		npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
 	 * })
 	 * 
 	 * ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -656,18 +656,20 @@ export interface KaboomCtx {
 	 */
 	agent(opt?: AgentCompOpt): AgentComp,
 	/**
-	 * Register an event on all game objs with certain tag.
+	 * Register a custom event available to all game objs that triggers it.
 	 *
 	 * @section Events
 	 *
 	 * @example
 	 * ```js
-	 * // a custom event defined by body() comp
-	 * // every time an obj with tag "bomb" hits the floor, destroy it and addKaboom()
-	 * on("ground", "bomb", (bomb) => {
-	 *     destroy(bomb)
-	 *     addKaboom(bomb.pos)
-	 * })
+   * // will display a message on the screen
+   * on("talk", (message, posX, posY) => {
+   *     add([text(message), pos(posX, posY - 100)])
+   * })
+   * onKeyPress("Space", () => {
+   *    npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
+   * })
+   * 
 	 * ```
 	 */
 	on(event: string, tag: Tag, action: (obj: GameObj, ...args: any) => void): EventController,

--- a/src/types.ts
+++ b/src/types.ts
@@ -673,13 +673,13 @@ export interface KaboomCtx {
 	 * // by passing a name and a callback function
 	 * on("talk", (message, posX, posY) => {
 	 *     add([
-	 * 		text(message), 
-	 * 		pos(posX, posY - 100)
-	 * 	   ])
+	 *      text(message), 
+	 *      pos(posX, posY - 100)
+	 *     ])
 	 * })
 	 * onKeyPress("space", () => {
-	 *    	// the trigger method on game objs can be used to trigger a custom event
-	 * 		npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
+	 *    // the trigger method on game objs can be used to trigger a custom event
+	 *    npc.trigger("talk", "Hello World!", npc.pos.x, npc.pos.y)
 	 * })
 	 * 
 	 * ```


### PR DESCRIPTION
In the Kaboom.js docs, it's not clear how to use the `on()` function used to define custom events.
I tried to improve the docs to make usage more clear.