### PR TITLE
add descriptions to doc entries, hide 3000.2v blog

### DIFF
--- a/blog/3000.2.md
+++ b/blog/3000.2.md
@@ -4,6 +4,7 @@ author: tga
 date: 12/31/2023
 description: Record mode, pretty texts, new events and more in this new version!
 image: 2000.1.png
+hidden: true
 ---
 
 # Kaboom v3000.2

--- a/doc/comp.md
+++ b/doc/comp.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Components
+description: Learn about create your own components for your game objects.
 ---
 
 # Custom Components

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,5 +1,6 @@
 ---
 title: Contributing
+description: Learn how to contribute to Kaboom.
 ---
 
 # Developing Kaboom

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+description: Learn the basics of Kaboom and make a simple game.
 ---
 
 # Intro to Kaboom

--- a/doc/migration-3000.md
+++ b/doc/migration-3000.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating from v2000 to v3000
+description: Migrate your codebase from Kaboom v2000 to v3000.
 ---
 
 # Migrating from v2000 to v3000

--- a/doc/publishing.md
+++ b/doc/publishing.md
@@ -1,5 +1,6 @@
 ---
 title: Publishing
+description: Learn how to publish your Kaboom game in platforms like Itch.io or Newgrounds.com.
 ---
 
 # Publishing a Kaboom game

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installation
+description: Learn how to install Kaboom.
 ---
 
 # Installation

--- a/doc/shaders.md
+++ b/doc/shaders.md
@@ -1,3 +1,8 @@
+---
+title: Shaders
+description: Learn how to write and use custom shaders in Kaboom.
+---
+
 # Writing a shader
 
 ## Vertex shader

--- a/doc/tips.md
+++ b/doc/tips.md
@@ -1,5 +1,6 @@
 ---
 title: Optimization
+description: Tips on optimizing performance / maintainability for kaboom games.
 ---
 
 # Optimization Tips


### PR DESCRIPTION
This PR add some descriptions to `doc/` entries, this will be useful for SEO and maybe a future searching?

Also adds hidden: true in frontmatter of `blog/3000.2`, because that version is not released! Then the property will be used in replit/kaboomsite to hide it from view.